### PR TITLE
WINDUP-2396 (MA) Deploy to Insights Test Environment - Change api prefix

### DIFF
--- a/profiles/local-frontend-and-api.js
+++ b/profiles/local-frontend-and-api.js
@@ -12,7 +12,7 @@ routes[`/${SECTION}/${APP_ID}`]      = { host: `http://localhost:${FRONTEND_PORT
 routes[`/beta/apps/${APP_ID}`]       = { host: `http://localhost:${FRONTEND_PORT}` };
 routes[`/apps/${APP_ID}`]            = { host: `http://localhost:${FRONTEND_PORT}` };
 
-routes[`/api/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };
-routes[`/camel`] = { host: `http://analytics-integration-ma.127.0.0.1.nip.io` };
+routes[`/api/xavier`] = { host: `http://localhost:${API_PORT}` };
+// routes[`/api/xavier`] = { host: `http://analytics-integration-ma.127.0.0.1.nip.io` };
 
 module.exports = { routes };

--- a/src/api/apiClient.tsx
+++ b/src/api/apiClient.tsx
@@ -1,5 +1,5 @@
 import axios, { AxiosPromise } from 'axios';
-export const NOTIFICATIONS_API_ROOT = '/api/migration-analytics';
+export const NOTIFICATIONS_API_ROOT = '/api/xavier';
 
 class BackendAPIClient {
     static request<T>(


### PR DESCRIPTION
Change our api prefix:
before:
`/api/migration-analytics`
after
`/api/xavier`