### PR TITLE
MIGENG-27 UX Implementation - Initial Savings Estimation Report - Fix percentage conversion

### DIFF
--- a/src/PresentationalComponents/Reports/Environment/Environment.test.tsx
+++ b/src/PresentationalComponents/Reports/Environment/Environment.test.tsx
@@ -8,7 +8,7 @@ const baseData: EnvironmentModel = {
   year1Hypervisor: 12,
   year2Hypervisor: 123,
   year3Hypervisor: 1234,
-  growthRatePercentage: 120
+  growthRatePercentage: 0.05
 };
 
 describe("Environment", () => {

--- a/src/PresentationalComponents/Reports/Environment/Environment.tsx
+++ b/src/PresentationalComponents/Reports/Environment/Environment.tsx
@@ -59,7 +59,7 @@ class Environment extends Component<Props, State> {
             [
                 'Year-over-year growth rate for new hypervisors',
                 '',
-                isNotNullOrUndefined(growthRatePercentage) ? 'Unknown' : `${growthRatePercentage.toLocaleString()}%`
+                isNotNullOrUndefined(growthRatePercentage) ? 'Unknown' : `${(growthRatePercentage * 100).toLocaleString()}%`
             ]
         ];
 

--- a/src/PresentationalComponents/Reports/Environment/__snapshots__/Environment.test.tsx.snap
+++ b/src/PresentationalComponents/Reports/Environment/__snapshots__/Environment.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Environment expect to render 1`] = `
         Array [
           "Year-over-year growth rate for new hypervisors",
           "",
-          "120%",
+          "5%",
         ],
       ]
     }


### PR DESCRIPTION
This change should allow the backend to send percentage values in the format:  **value > 0 && value < 1**. Then the UI will multiply the value by 100 and show it to the user.

 As a result:
![Screenshot from 2019-07-18 13-30-06](https://user-images.githubusercontent.com/2582866/61454103-3739cc00-a960-11e9-8356-5ead69dc68e4.png)
