### PR TITLE
MIGENG-33 - UX Implementation - Report Management UI - Fix percentage values sent to the backend

### DIFF
--- a/src/pages/ReportsUpload/ReportsUpload.tsx
+++ b/src/pages/ReportsUpload/ReportsUpload.tsx
@@ -228,7 +228,7 @@ class ReportsUpload extends React.Component<Props, State> {
             file: this.props.file,
             reportName: values.reportName,
             reportDescription: values.reportDescription,
-            yearOverYearGrowthRatePercentage: values.yearOverYearGrowthRatePercentage,
+            yearOverYearGrowthRatePercentage: values.yearOverYearGrowthRatePercentage / 100 ,
             percentageOfHypervisorsMigratedOnYear1: values.percentageOfHypervisorsMigratedOnYear1 / 100,
             percentageOfHypervisorsMigratedOnYear2: values.percentageOfHypervisorsMigratedOnYear2 / 100,
             percentageOfHypervisorsMigratedOnYear3: values.percentageOfHypervisorsMigratedOnYear3 / 100

--- a/src/pages/ReportsUpload/ReportsUpload.tsx
+++ b/src/pages/ReportsUpload/ReportsUpload.tsx
@@ -229,9 +229,9 @@ class ReportsUpload extends React.Component<Props, State> {
             reportName: values.reportName,
             reportDescription: values.reportDescription,
             yearOverYearGrowthRatePercentage: values.yearOverYearGrowthRatePercentage,
-            percentageOfHypervisorsMigratedOnYear1: values.percentageOfHypervisorsMigratedOnYear1,
-            percentageOfHypervisorsMigratedOnYear2: values.percentageOfHypervisorsMigratedOnYear2,
-            percentageOfHypervisorsMigratedOnYear3: values.percentageOfHypervisorsMigratedOnYear3
+            percentageOfHypervisorsMigratedOnYear1: values.percentageOfHypervisorsMigratedOnYear1 / 100,
+            percentageOfHypervisorsMigratedOnYear2: values.percentageOfHypervisorsMigratedOnYear2 / 100,
+            percentageOfHypervisorsMigratedOnYear3: values.percentageOfHypervisorsMigratedOnYear3 / 100
         };
 
         const config = {


### PR DESCRIPTION
- Before:
The user writes **5%**, then the UI sends to the backend the value of **5** as a number.

- After
The user writes **5%**, then the UI sends to the backend the value of **0.05** as a number.

This change applies to:
1. yearOverYearGrowthRatePercentage
1. percentageOfHypervisorsMigratedOnYear1
1. percentageOfHypervisorsMigratedOnYear2
1. percentageOfHypervisorsMigratedOnYear3

![Screenshot from 2019-07-09 16-29-39](https://user-images.githubusercontent.com/2582866/61454763-170b0c80-a962-11e9-9608-e69f083b549a.png)
