### PR TITLE
Avoid calling the back-end before the authentication process finishes

### DIFF
--- a/src/SmartComponents/UserRoute/UserRoute.tsx
+++ b/src/SmartComponents/UserRoute/UserRoute.tsx
@@ -3,6 +3,8 @@ import { Route, Redirect } from 'react-router-dom';
 import { User } from '../../models';
 import { ObjectFetchStatus } from '../../models/state';
 
+declare var insights: any;
+
 interface StateToProps {
     user: User | null;
     userFetchStatus: ObjectFetchStatus;
@@ -25,7 +27,11 @@ class UserRoute extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        this.props.fetchUser();
+        // Load SSO user to prevent calling the backend before the auth
+        // process finishes
+        insights.chrome.auth.getUser().then(() => {
+            this.props.fetchUser();
+        });
     }
 
     render() {


### PR DESCRIPTION
This change is forcing to load the session user before calling the backend. It should fix the problem occurred when first loading the Home page "Failed to load user"