### PR TITLE
MIGENG-191 UX Initial Savings Estimation - Barchart tooltip not readable

### DIFF
--- a/src/PresentationalComponents/FancyGroupedBarChart/FancyGroupedBarChart.tsx
+++ b/src/PresentationalComponents/FancyGroupedBarChart/FancyGroupedBarChart.tsx
@@ -108,7 +108,7 @@ class FancyGroupedBarChart extends Component<Props, State> {
                                     <ChartBar
                                         key={ index }
                                         data={ value }
-                                        labelComponent={ <ChartTooltip style={ { color: 'white' } }/> }
+                                        labelComponent={ <ChartTooltip /> }
                                         { ...chartBarProps }
                                     />
                                 );

--- a/src/PresentationalComponents/FancyGroupedBarChart/__snapshots__/FancyGroupedBarChart.test.tsx.snap
+++ b/src/PresentationalComponents/FancyGroupedBarChart/__snapshots__/FancyGroupedBarChart.test.tsx.snap
@@ -77,15 +77,7 @@ exports[`FancyGroupedBarChart expect to render footer 1`] = `
             ]
           }
           key="0"
-          labelComponent={
-            <ChartTooltip
-              style={
-                Object {
-                  "color": "white",
-                }
-              }
-            />
-          }
+          labelComponent={<ChartTooltip />}
         />
         <ChartBar
           data={
@@ -108,15 +100,7 @@ exports[`FancyGroupedBarChart expect to render footer 1`] = `
             ]
           }
           key="1"
-          labelComponent={
-            <ChartTooltip
-              style={
-                Object {
-                  "color": "white",
-                }
-              }
-            />
-          }
+          labelComponent={<ChartTooltip />}
         />
       </ChartGroup>
     </Chart>
@@ -208,15 +192,7 @@ exports[`FancyGroupedBarChart expect to render with minimun props 1`] = `
             ]
           }
           key="0"
-          labelComponent={
-            <ChartTooltip
-              style={
-                Object {
-                  "color": "white",
-                }
-              }
-            />
-          }
+          labelComponent={<ChartTooltip />}
         />
         <ChartBar
           data={
@@ -239,15 +215,7 @@ exports[`FancyGroupedBarChart expect to render with minimun props 1`] = `
             ]
           }
           key="1"
-          labelComponent={
-            <ChartTooltip
-              style={
-                Object {
-                  "color": "white",
-                }
-              }
-            />
-          }
+          labelComponent={<ChartTooltip />}
         />
       </ChartGroup>
     </Chart>


### PR DESCRIPTION
Problem:
If the user puts the mouse over a bar, then the Tooltip is partially hidden

This PR solves that problem. The problem was caused by a custom color for the tooltip I was using. Now I removed it and using the default configuration

https://jira.coreos.com/browse/MIGENG-142