### PR TITLE
Change WSR - Target recommendation label

### DIFF
--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -188,7 +188,7 @@ class WorkloadMigrationSummary extends React.Component<Props, State> {
                             { formatPercentage(percentages[2], 0) } RHEL
                         </h2>
                         <h3 className="pf-c-title pf-m-1xl">
-                            Workloads possible to migrate to RHEL
+                            Workloads possible to migrate to Red Hat Enterprise Linux
                         </h3>
                     </div>
                 </div>

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -188,7 +188,7 @@ class WorkloadMigrationSummary extends React.Component<Props, State> {
                             { formatPercentage(percentages[2], 0) } RHEL
                         </h2>
                         <h3 className="pf-c-title pf-m-1xl">
-                            Workloads running, or possible to migrate to Red Hat Enterprise Linux
+                            Workloads possible to migrate to RHEL
                         </h3>
                     </div>
                 </div>


### PR DESCRIPTION
Changed the Workload Summary Report / Target recommendation:
- Change from "Workloads running, or possible to migrate to Red Hat Enterprise Linux" to "Workloads possible to migrate to RHEL"

BEFORE:
![Screenshot from 2019-09-03 17-35-26](https://user-images.githubusercontent.com/2582866/64187653-4c67ad00-ce71-11e9-9eeb-8f1262b8896b.png)

AFTER:
![Screenshot from 2019-09-03 17-35-38](https://user-images.githubusercontent.com/2582866/64187658-51c4f780-ce71-11e9-9958-614413fbd691.png)
