### PR TITLE
WMS - Workloads detected (OS Types): add workloads to tooltip

### DIFF
--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -240,10 +240,13 @@ class WorkloadMigrationSummary extends React.Component<Props, State> {
 
         const chartData: FancyChartDonutData[] = workloadsDetectedOSTypeModels.map((element, index: number) => ({
             label: element.osName,
-            value: percentages[index]
+            value: percentages[index],
+            data: pieValues[index]
         }));
 
         const tickFormat = (label: string, value: number) => `${label}: ${formatPercentage(value, 2)}`;
+        const tooltipFormat = (datum: any, active: boolean) => `${datum.x}: ${formatPercentage(datum.y, 2)} \n Workloads: ${formatNumber(datum.data, 0)}`;
+
         return (
             <ReportCard
                 title={title}
@@ -253,6 +256,7 @@ class WorkloadMigrationSummary extends React.Component<Props, State> {
                     chartProps={ chartProps }
                     chartLegendProps={ chartLegendProps }
                     tickFormat={ tickFormat }
+                    tooltipFormat={ tooltipFormat }
                 />
             </ReportCard>
         );


### PR DESCRIPTION
Changed the Workload Migration Summary Report - Workloads detected (OS Types)
- Added a second line in the Donut chart tooltip to present to the user complete information about the percentage's original values

BEFORE:
![Screenshot from 2019-09-03 17-46-27](https://user-images.githubusercontent.com/2582866/64188626-0f9cb580-ce73-11e9-9844-0fbf9485806d.png)

AFTER:
![Screenshot from 2019-09-03 17-46-54](https://user-images.githubusercontent.com/2582866/64188634-13c8d300-ce73-11e9-8577-25b3634b0ad8.png)
