### PR TITLE
Initial Savings Estimation - reduce left padding of barcharts

### DIFF
--- a/src/PresentationalComponents/FancyGroupedBarChart/FancyGroupedBarChart.scss
+++ b/src/PresentationalComponents/FancyGroupedBarChart/FancyGroupedBarChart.scss
@@ -5,3 +5,7 @@
     stroke: transparent;
     fill: rgb(21, 21, 21);
 }
+
+.fancy-groupped-bar-chart-container {
+    width: 100%;
+}

--- a/src/PresentationalComponents/FancyGroupedBarChart/FancyGroupedBarChart.tsx
+++ b/src/PresentationalComponents/FancyGroupedBarChart/FancyGroupedBarChart.tsx
@@ -42,7 +42,7 @@ interface State {
 
 const baseLegendStyle = {
     labels: {
-        fontSize: 12
+        fontSize: 9
     }
 };
 
@@ -79,7 +79,7 @@ class FancyGroupedBarChart extends Component<Props, State> {
 
         return (
             <React.Fragment>
-                <div className="bar-chart-container">
+                <div className="fancy-groupped-bar-chart-container">
                     {
                         data.legends &&
                         <ChartLegend

--- a/src/PresentationalComponents/FancyGroupedBarChart/__snapshots__/FancyGroupedBarChart.test.tsx.snap
+++ b/src/PresentationalComponents/FancyGroupedBarChart/__snapshots__/FancyGroupedBarChart.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FancyGroupedBarChart expect to render footer 1`] = `
 <Fragment>
   <div
-    className="bar-chart-container"
+    className="fancy-groupped-bar-chart-container"
   >
     <ChartLegend
       colorScale={
@@ -26,7 +26,7 @@ exports[`FancyGroupedBarChart expect to render footer 1`] = `
       style={
         Object {
           "labels": Object {
-            "fontSize": 12,
+            "fontSize": 9,
           },
         }
       }
@@ -118,7 +118,7 @@ exports[`FancyGroupedBarChart expect to render footer 1`] = `
 exports[`FancyGroupedBarChart expect to render with minimun props 1`] = `
 <Fragment>
   <div
-    className="bar-chart-container"
+    className="fancy-groupped-bar-chart-container"
   >
     <ChartLegend
       colorScale={
@@ -141,7 +141,7 @@ exports[`FancyGroupedBarChart expect to render with minimun props 1`] = `
       style={
         Object {
           "labels": Object {
-            "fontSize": 12,
+            "fontSize": 9,
           },
         }
       }

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -115,7 +115,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                 x: 110,
                 y: 60
             },
-            padding: { left: 150, right: 20, bottom: 30, top: 0 }
+            padding: { left: 110, right: 20, bottom: 30, top: 0 }
         };
         const chartGroupProps: ChartGroupProps = { offset: 50 };
         const chartBarProps: ChartBarProps = { barWidth: 50 };
@@ -143,7 +143,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
 
         const footer = (
             <div className="pf-u-text-align-center">
-                <span style={ { marginLeft: 130 } }>Year</span>
+                <span style={ { marginLeft: 95 } }>Year</span>
             </div>
         );
 
@@ -314,7 +314,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                 x: 50,
                 y: 60
             },
-            padding: { left: 150, right: 0, bottom: 100, top: 0 }
+            padding: { left: 110, right: 0, bottom: 100, top: 0 }
         };
         const chartGroupProps: ChartGroupProps = { offset: 0 };
         const chartBarProps: ChartBarProps = { barWidth: 50 };
@@ -347,7 +347,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
 
         const footer = (
             <div className="pf-u-text-align-center">
-                <span style={ { marginLeft: 130 } }>Migration Cost Breakdown</span>
+                <span style={ { marginLeft: 70 } }>Migration Cost Breakdown</span>
             </div>
         );
 


### PR DESCRIPTION
Reduce left padding of:
- Cost expenditure comparison during the 3 year migration
- Project cost breakdown

I can not reduce the padding to 0 but I've reduced the padding in a way that values less or equal than 99,000,000 can still be visible in the chart.

Before:
![Screenshot from 2019-09-04 14-19-43](https://user-images.githubusercontent.com/2582866/64254318-7081c780-cf1f-11e9-8e84-cadacd15af57.png)

After:
![Screenshot from 2019-09-04 14-19-26](https://user-images.githubusercontent.com/2582866/64254317-7081c780-cf1f-11e9-99c0-d6cb2fb244d3.png)
