### PR TITLE
Workload Migration Summary: Remove borders from No-results table

### DIFF
--- a/src/SmartComponents/Reports/FlagsTable/FlagsTable.tsx
+++ b/src/SmartComponents/Reports/FlagsTable/FlagsTable.tsx
@@ -26,10 +26,7 @@ import {
     EmptyStateVariant,
     Title,
     TitleLevel,
-    EmptyStateBody,
-    Card,
-    CardBody
-} from '@patternfly/react-core';
+    EmptyStateBody} from '@patternfly/react-core';
 import { ErrorCircleOIcon, SearchIcon } from '@patternfly/react-icons';
 import { FlagModel } from '../../../models';
 import { ObjectFetchStatus } from '../../../models/state';
@@ -254,17 +251,15 @@ class FlagsTable extends React.Component<Props, State> {
     public renderNoResults = () => {
         return (
             <React.Fragment>
-                <Card>
-                    <CardBody>
-                        <EmptyState variant={ EmptyStateVariant.full }>
-                            <EmptyStateIcon icon={ SearchIcon } />
-                            <Title headingLevel="h5" size="lg">No results found</Title>
-                            <EmptyStateBody>
-                                No results match the search criteria
-                            </EmptyStateBody>
-                        </EmptyState>
-                    </CardBody>
-                </Card>
+                <Bullseye>
+                    <EmptyState variant={ EmptyStateVariant.full }>
+                        <EmptyStateIcon icon={ SearchIcon } />
+                        <Title headingLevel="h5" size="lg">No results found</Title>
+                        <EmptyStateBody>
+                            No results match the search criteria
+                        </EmptyStateBody>
+                    </EmptyState>
+                </Bullseye>
             </React.Fragment>
         );
     };

--- a/src/SmartComponents/Reports/WorkloadsDetectedTable/WorkloadsDetectedTable.tsx
+++ b/src/SmartComponents/Reports/WorkloadsDetectedTable/WorkloadsDetectedTable.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { RouterGlobalProps } from '../../../models/router';
 import {
     TableToolbar,
-    Skeleton,
     SkeletonTable
 } from '@redhat-cloud-services/frontend-components';
 import {
@@ -27,12 +26,7 @@ import {
     EmptyStateVariant,
     Title,
     TitleLevel,
-    EmptyStateBody,
-    Stack,
-    StackItem,
-    Card,
-    CardBody
-} from '@patternfly/react-core';
+    EmptyStateBody} from '@patternfly/react-core';
 import { ErrorCircleOIcon, SearchIcon } from '@patternfly/react-icons';
 import { WorkloadModel } from '../../../models';
 import { ObjectFetchStatus } from '../../../models/state';
@@ -250,17 +244,15 @@ class WorkloadsDetectedTable extends React.Component<Props, State> {
     public renderNoResults = () => {
         return (
             <React.Fragment>
-                <Card>
-                    <CardBody>
-                        <EmptyState variant={ EmptyStateVariant.full }>
-                            <EmptyStateIcon icon={ SearchIcon } />
-                            <Title headingLevel="h5" size="lg">No results found</Title>
-                            <EmptyStateBody>
-                                No results match the search criteria
-                            </EmptyStateBody>
-                        </EmptyState>
-                    </CardBody>
-                </Card>
+                <Bullseye>
+                    <EmptyState variant={ EmptyStateVariant.full }>
+                        <EmptyStateIcon icon={ SearchIcon } />
+                        <Title headingLevel="h5" size="lg">No results found</Title>
+                        <EmptyStateBody>
+                            No results match the search criteria
+                        </EmptyStateBody>
+                    </EmptyState>
+                </Bullseye>
             </React.Fragment>
         );
     };


### PR DESCRIPTION
When No-Results tables are shown, there is a border which is unnecessary; it is caused by double CARD component used.

Affected tables: 
- Workloads detected
- Flags (Considerations to be migrated)

BEFORE:
![Screenshot from 2019-09-05 09-42-01](https://user-images.githubusercontent.com/2582866/64322950-cdcf5480-cfc3-11e9-8a6b-8ab42e7ce76f.png)

AFTER
![Screenshot from 2019-09-05 09-46-46](https://user-images.githubusercontent.com/2582866/64322961-d2940880-cfc3-11e9-932e-aa575a949c64.png)
