### PR TITLE
Workload Migration Summary: change Skeleton layout

### DIFF
--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -331,18 +331,8 @@ class WorkloadMigrationSummary extends React.Component<Props, State> {
                     <StackItem isFilled={ false }>
                         <ReportCard
                             title={ <Skeleton size="sm" /> }
-                            skipBullseye={ true }
                         >
-                            <Stack gutter="md">
-                                <StackItem isFilled={ false }>
-                                    <Skeleton size="sm" /><br />
-                                    <Skeleton size="sm" style={ { height: '60px' } } /><br />
-                                    <Skeleton size="sm" />
-                                </StackItem>
-                                <StackItem isFilled={ false } className="stack-item-border">
-                                    <Skeleton size="lg"/>
-                                </StackItem>
-                            </Stack>
+                            <SkeletonTable colSize={ 7 } rowSize={ 3 }/>
                         </ReportCard>
                     </StackItem>
                     <StackItem isFilled={ false }>
@@ -356,14 +346,7 @@ class WorkloadMigrationSummary extends React.Component<Props, State> {
                         <ReportCard
                             title={ <Skeleton size="sm" /> }
                         >
-                            <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
-                        </ReportCard>
-                    </StackItem>
-                    <StackItem isFilled={ false }>
-                        <ReportCard
-                            title={ <Skeleton size="sm" /> }
-                        >
-                            <SkeletonTable colSize={ 2 } rowSize={ 2 }/>
+                            <SkeletonTable colSize={ 3 } rowSize={ 1  }/>
                         </ReportCard>
                     </StackItem>
                 </Stack>


### PR DESCRIPTION
Changed the Skeleton layout of Workload Migration Summary Report to better represent the report layout.

The screenshot below is the final view of the report:
![Screenshot from 2019-09-05 10-16-55](https://user-images.githubusercontent.com/2582866/64324301-649d1080-cfc6-11e9-8b23-19e6f71d959f.png)

**BEFORE CHANGES:**
![Screenshot from 2019-09-05 10-10-57](https://user-images.githubusercontent.com/2582866/64324221-37506280-cfc6-11e9-9fdc-60281ff0d122.png)

**AFTER CHANGES (this is a better skeleton for the final report view)**
![Screenshot from 2019-09-05 10-10-21](https://user-images.githubusercontent.com/2582866/64324234-3c151680-cfc6-11e9-8b8d-49c67f641ae1.png)
