### PR TITLE
MIGENG-129: MA - MIME Type Validation

### DIFF
--- a/src/pages/ReportsUpload/ReportsUpload.tsx
+++ b/src/pages/ReportsUpload/ReportsUpload.tsx
@@ -245,7 +245,10 @@ class ReportsUpload extends React.Component<Props, State> {
     };
 
     public onFileSelected = (files: File[]): void => {
-        this.props.selectUploadFile(files[0]);
+        const selectedFile = files[0];
+        if (selectedFile) {
+            this.props.selectUploadFile(selectedFile);
+        }
     };
 
     public renderProgress() {

--- a/src/pages/ReportsUpload/ReportsUpload.tsx
+++ b/src/pages/ReportsUpload/ReportsUpload.tsx
@@ -32,7 +32,7 @@ import UploadForm from './UploadForm';
 import { validateForm } from '../../Utilities/formUtils';
 
 interface FormValues {
-    file: string;
+    file: File | undefined;
     reportName: string;
     reportDescription: string;
     yearOverYearGrowthRatePercentage: number;
@@ -69,7 +69,7 @@ interface State {
 }
 
 const initialFormValue: FormValues = {
-    file: '',
+    file: undefined,
     reportName: '',
     reportDescription: '',
     yearOverYearGrowthRatePercentage: 5,
@@ -81,8 +81,17 @@ const initialFormValue: FormValues = {
 
 const formValidationSchema = (values: FormValues) => {
     return Yup.object().shape({
-        file: Yup.string()
-        .required('File is mandatory'),
+        file: Yup.mixed()
+        .required('File is mandatory')
+        .test('validFileSize', 'File size must not exceed 1GB', () => {
+            if (values.file) {
+                const fileSize = values.file.size;
+                return fileSize > 0 && fileSize <= 1073741824;
+            }
+
+            // If there is no file then 'validFileSize' is valid
+            return true;
+        }),
         reportName: Yup.string()
         .min(3, 'Report name must contain at least 3 characters ')
         .max(250, 'Report name must contain fewer than 250 characters')

--- a/src/pages/ReportsUpload/UploadForm.tsx
+++ b/src/pages/ReportsUpload/UploadForm.tsx
@@ -92,13 +92,7 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                         onDrop={ onDrop }
                         noClick={true} noKeyboard={true}
                         multiple={ false }
-                        accept={ [
-                            'application/zip',
-                            'application/json',
-                            'application/gzip',
-                            'application/tar',
-                            'application/tar+gzip'
-                        ] }
+                        maxSize={ 1073741824 }
                     >
                         { ({ getRootProps, getInputProps, open }) => {
                             return (

--- a/src/pages/ReportsUpload/UploadForm.tsx
+++ b/src/pages/ReportsUpload/UploadForm.tsx
@@ -48,11 +48,11 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
 
     public updateFieldValues() {
         if (this.props.file) {
-            const fileName = this.props.file.name;
+            const file: File = this.props.file;
             setTimeout(() => {
-                this.props.setFieldValue('file', fileName);
+                this.props.setFieldValue('file', file);
                 if (!this.props.values.reportName) {
-                    const fileNameWithoutExtension = fileName.replace(/\.[^/.]+$/, "");
+                    const fileNameWithoutExtension = file.name.replace(/\.[^/.]+$/, "");
                     this.props.setFieldValue('reportName', fileNameWithoutExtension);
                 }
             }, 0);
@@ -85,14 +85,14 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                     fieldId="file"
                     helperTextInvalid={ errors.file }
                     isValid={
-                        (errors.file && touched.file) ? false : true
+                        (errors.file) ? false : true
                     }
                 >
                     <Dropzone
                         onDrop={ onDrop }
-                        noClick={true} noKeyboard={true}
+                        noClick={ true }
+                        noKeyboard={ true }
                         multiple={ false }
-                        maxSize={ 1073741824 }
                     >
                         { ({ getRootProps, getInputProps, open }) => {
                             return (
@@ -105,7 +105,7 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                                                 name="file"
                                                 type="text"
                                                 aria-label="Select a File"
-                                                value={ values.file }
+                                                value={ values.file ? values.file.name : '' }
                                                 isValid={
                                                     (errors.file && touched.file) ? false : true
                                                 } />

--- a/src/pages/ReportsUpload/__snapshots__/ReportsUpload.test.tsx.snap
+++ b/src/pages/ReportsUpload/__snapshots__/ReportsUpload.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ReportsUpload expect to render form 1`] = `
         enableReinitialize={false}
         initialValues={
           Object {
-            "file": "",
+            "file": undefined,
             "percentageOfHypervisorsMigratedOnYear1": 50,
             "percentageOfHypervisorsMigratedOnYear2": 30,
             "percentageOfHypervisorsMigratedOnYear3": 20,

--- a/src/pages/ReportsUpload/__snapshots__/UploadForm.test.tsx.snap
+++ b/src/pages/ReportsUpload/__snapshots__/UploadForm.test.tsx.snap
@@ -11,15 +11,7 @@ exports[`UploadForm expect to render 1`] = `
     label="Inventory data file"
   >
     <Dropzone
-      accept={
-        Array [
-          "application/zip",
-          "application/json",
-          "application/gzip",
-          "application/tar",
-          "application/tar+gzip",
-        ]
-      }
+      maxSize={1073741824}
       multiple={false}
       noClick={true}
       noKeyboard={true}
@@ -248,15 +240,7 @@ exports[`UploadForm expect to render errors 1`] = `
     label="Inventory data file"
   >
     <Dropzone
-      accept={
-        Array [
-          "application/zip",
-          "application/json",
-          "application/gzip",
-          "application/tar",
-          "application/tar+gzip",
-        ]
-      }
+      maxSize={1073741824}
       multiple={false}
       noClick={true}
       noKeyboard={true}

--- a/src/pages/ReportsUpload/__snapshots__/UploadForm.test.tsx.snap
+++ b/src/pages/ReportsUpload/__snapshots__/UploadForm.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`UploadForm expect to render 1`] = `
     label="Inventory data file"
   >
     <Dropzone
-      maxSize={1073741824}
       multiple={false}
       noClick={true}
       noKeyboard={true}
@@ -240,7 +239,6 @@ exports[`UploadForm expect to render errors 1`] = `
     label="Inventory data file"
   >
     <Dropzone
-      maxSize={1073741824}
       multiple={false}
       noClick={true}
       noKeyboard={true}


### PR DESCRIPTION
Changes in the Upload Form:

- Removed `accept` validation. Now the user will be able to select any file with any extension. This change is due to every Operating System have different Mime-type and the current UI is not working on Mac or Windows OS.
- Added maxSize validation. **Current MaxSize is 1073741824Kb (1GB)**