### PR TITLE
MIGENG-194: MA - Analysis List - include timestamp in dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "scripts": {
     "build": "webpack --config config/prod.webpack.config.js",
-    "test": "jest --verbose",
+    "test": "TZ=UTC jest --verbose",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint config src",
     "lint:js:fix": "eslint config src --fix",

--- a/src/PresentationalComponents/ReportViewPage/__snapshots__/ReportViewPage.test.tsx.snap
+++ b/src/PresentationalComponents/ReportViewPage/__snapshots__/ReportViewPage.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`ReportViewPage expect to render tabs when fetch status is complete 1`] 
               </span>
                
               <span>
-                January 2, 1970 11:17 AM
+                January 2, 1970 10:17 AM
               </span>
             </p>
           </div>

--- a/src/PresentationalComponents/ReportViewPage/__snapshots__/ReportViewPage.test.tsx.snap
+++ b/src/PresentationalComponents/ReportViewPage/__snapshots__/ReportViewPage.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`ReportViewPage expect to render tabs when fetch status is complete 1`] 
               </span>
                
               <span>
-                2 January 1970
+                January 2, 1970 11:17 AM
               </span>
             </p>
           </div>

--- a/src/PresentationalComponents/Reports/ScansRunTable/ScansRunTable.tsx
+++ b/src/PresentationalComponents/Reports/ScansRunTable/ScansRunTable.tsx
@@ -38,7 +38,7 @@ class ScansRunTable extends Component<Props, State> {
             return [
                 element.target,
                 element.type,
-                formatDate(new Date(element.date))
+                formatDate(new Date(element.date), false)
             ];
         });
 

--- a/src/Utilities/formatValue.js
+++ b/src/Utilities/formatValue.js
@@ -49,12 +49,12 @@ export const formatValue = (value, unit, options = {}) => {
 };
 
 export const formatDate = value => {
-    const locale = 'default';
-    const day = value.getDate();
-    const month = value.toLocaleString(locale, { month: 'long' });
-    const year = value.getFullYear();
+    /*eslint new-cap: 0*/
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const dateOptions = { timeZone, year: 'numeric', month: 'long', day: 'numeric' };
+    const timeOptions = { timeZone, hour: '2-digit', minute: '2-digit' };
 
-    return day + ' ' + month + ' ' + year;
+    return value.toLocaleDateString('en', dateOptions) + ' ' + value.toLocaleTimeString('en', timeOptions);
 };
 
 export const formatNumber = (value, fractionDigits = 2) => {

--- a/src/Utilities/formatValue.js
+++ b/src/Utilities/formatValue.js
@@ -48,13 +48,20 @@ export const formatValue = (value, unit, options = {}) => {
     }
 };
 
-export const formatDate = value => {
+export const formatDate = (value, includeTime = true) => {
     /*eslint new-cap: 0*/
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const dateOptions = { timeZone, year: 'numeric', month: 'long', day: 'numeric' };
     const timeOptions = { timeZone, hour: '2-digit', minute: '2-digit' };
 
-    return value.toLocaleDateString('en', dateOptions) + ' ' + value.toLocaleTimeString('en', timeOptions);
+    let result = value.toLocaleDateString('en', dateOptions);
+
+    if (includeTime) {
+        const timeString = value.toLocaleTimeString('en', timeOptions);
+        result += ' ' + timeString;
+    }
+
+    return result;
 };
 
 export const formatNumber = (value, fractionDigits = 2) => {


### PR DESCRIPTION
https://jira.coreos.com/browse/MIGENG-194

Changes:
- Change date to EN format.
**Before:**
15 May 2019
**After:**
May 15, 2019

- Added time (just hour and minute) to dates.
e.g. September 19, 2019 5:38 PM

![Screenshot from 2019-09-20 11-13-53](https://user-images.githubusercontent.com/2582866/65315079-c4371680-db97-11e9-8409-da254cbcaee6.png)

The current version is using EN format for numbers and I think we should use EN formatting for dates as well. When we will add internationalization we can change the date format.