### PR TITLE
MIGENG-279: 'Export as CSV' does not export filtered result

### DIFF
--- a/src/actions/ReportActions.tsx
+++ b/src/actions/ReportActions.tsx
@@ -7,7 +7,8 @@ import {
     getReportFlags,
     getReportInitialSavingestimation,
     getReportWorkloadInventory,
-    getReportWorkloadInventoryCSV,
+    getReportWorkloadInventoryAllCSV,
+    getReportWorkloadInventoryFilteredCSV,
     getReportWorkloadInventoryAvailableFilters
 } from '../api/report';
 import { GenericAction } from '../models/action';
@@ -21,7 +22,8 @@ export const ActionTypes = {
     FETCH_REPORT_FLAGS: 'FETCH_REPORT_FLAGS',
     FETCH_REPORT_INITIAL_SAVING_ESTIMATION: 'FETCH_REPORT_INITIAL_SAVING_ESTIMATION',
     FETCH_REPORT_WOKLOAD_INVENTORY: 'FETCH_REPORT_WOKLOAD_INVENTORY',
-    FETCH_REPORT_WOKLOAD_INVENTORY_CSV: 'FETCH_REPORT_WOKLOAD_INVENTORY_CSV',
+    FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV: 'FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV',
+    FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV: 'FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV',
     FETCH_REPORT_WOKLOAD_INVENTORY_AVAILABLE_FILTERS: 'FETCH_REPORT_WOKLOAD_INVENTORY_AVAILABLE_FILTERS'
 };
 
@@ -161,14 +163,32 @@ export const fetchReportWorkloadInventory = (
     }
 });
 
-export const fetchReportWorkloadInventoryCSV = (id: number): GenericAction => ({
-    type: ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_CSV,
-    payload: getReportWorkloadInventoryCSV(id),
+export const fetchReportWorkloadInventoryAllCSV = (id: number): GenericAction => ({
+    type: ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV,
+    payload: getReportWorkloadInventoryAllCSV(id),
     meta: {
         notifications: {
             rejected: {
                 variant: 'danger',
-                title: `Failed to load report workload inventory ${id}`
+                title: `Failed to load report workload inventory ${id} csv`
+            }
+        }
+    }
+});
+
+export const fetchReportWorkloadInventoryFilteredCSV = (
+    id: number,
+    orderBy: string,
+    orderDirection: 'asc' | 'desc' | undefined,
+    filters: Map<string, string[]>
+): GenericAction => ({
+    type: ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV,
+    payload: getReportWorkloadInventoryFilteredCSV(id, orderBy, orderDirection, filters),
+    meta: {
+        notifications: {
+            rejected: {
+                variant: 'danger',
+                title: `Failed to load report workload inventory ${id} csv`
             }
         }
     }

--- a/src/api/report.tsx
+++ b/src/api/report.tsx
@@ -133,7 +133,40 @@ export function getReportWorkloadInventory(
     return ApiClient.get<SearchResult<ReportWorkloadInventory>>(url);
 }
 
-export function getReportWorkloadInventoryCSV(id: number): AxiosPromise<any> {
+export function getReportWorkloadInventoryFilteredCSV(
+    id: number,
+    orderBy: string,
+    orderDirection: 'asc' | 'desc' | undefined,
+    filters: Map<string, string[]>
+): AxiosPromise<any> {
+    const params = {
+        orderBy,
+        orderAsc: orderDirection ? orderDirection === 'asc' : undefined
+    };
+    const query: string[] = [];
+
+    Object.keys(params).map(key => {
+        const value = params[key];
+        if (value !== undefined) {
+            query.push(`${key}=${value}`);
+        }
+    });
+
+    filters.forEach((arrayValue: string[], key: string) => {
+        if (arrayValue.length > 0) {
+            arrayValue.forEach(value => {
+                query.push(`${key}=${value}`);
+            });
+        }
+    });
+
+    const url = `/report/${id}/workload-inventory/filtered-csv?${query.join('&')}`;
+    return ApiClient.request<any>(url, null, 'get', {
+        responseType: 'blob'
+    });
+}
+
+export function getReportWorkloadInventoryAllCSV(id: number): AxiosPromise<any> {
     const url = `/report/${id}/workload-inventory/csv`;
     return ApiClient.request<any>(url, null, 'get', {
         responseType: 'blob'

--- a/src/models/state/index.tsx
+++ b/src/models/state/index.tsx
@@ -64,7 +64,8 @@ export interface ReportState {
         items: ReportWorkloadInventory[]
     };
     reportWorkloadInventoryFetchStatus: ObjectFetchStatus;
-    reportWorkloadInventoryCSVFetchStatus: ObjectFetchStatus;
+    reportWorkloadInventoryAllCSVFetchStatus: ObjectFetchStatus;
+    reportWorkloadInventoryFilteredCSVFetchStatus: ObjectFetchStatus;
 
     reportWorkloadInventoryAvailableFilters: WorkloadInventoryReportFiltersModel | null;
     reportWorkloadInventoryAvailableFiltersFetchStatus: ObjectFetchStatus;

--- a/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
+++ b/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
@@ -297,7 +297,8 @@ class WorkloadInventory extends React.Component<Props, State> {
         const orderByColumn = sortBy.index ? this.state.columns[sortBy.index-1].key : undefined;
         const orderDirection = sortBy.direction ? sortBy.direction : undefined;
         
-        fetchReportWorkloadInventoryFilteredCSV(reportId, orderByColumn, orderDirection, filterValue).then((response: any) => {
+        const mappedFilterValue = this.prepareFiltersToBeSended(filterValue);
+        fetchReportWorkloadInventoryFilteredCSV(reportId, orderByColumn, orderDirection, mappedFilterValue).then((response: any) => {
             const contentDispositionHeader = response.value.headers['content-disposition'];
             const fileName = extractFilenameFromContentDispositionHeaderValue(contentDispositionHeader);
 

--- a/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
+++ b/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
@@ -46,7 +46,8 @@ import {
     ChipGroupToolbarItem,
     Chip,
     ButtonVariant,
-    Form
+    Form,
+    KebabToggle
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, SearchIcon, FilterIcon } from '@patternfly/react-icons';
 import './WorkloadInventory.scss';
@@ -64,7 +65,8 @@ interface StateToProps extends RouterGlobalProps {
         items: ReportWorkloadInventory[]
     };
     reportWorkloadInventoryFetchStatus: ObjectFetchStatus;
-    reportWorkloadInventoryCSVFetchStatus: ObjectFetchStatus;
+    reportWorkloadInventoryAllCSVFetchStatus: ObjectFetchStatus;
+    reportWorkloadInventoryFilteredCSVFetchStatus: ObjectFetchStatus;
     reportWorkloadInventoryAvailableFilters: WorkloadInventoryReportFiltersModel;
     reportWorkloadInventoryAvailableFiltersFetchStatus: ObjectFetchStatus;
 }
@@ -78,7 +80,13 @@ interface DispatchToProps {
         orderDirection: 'asc' | 'desc' | undefined,
         filterValue: Map<string, string[]>
     ) => any;
-    fetchReportWorkloadInventoryCSV:(reportId: number) => any;
+    fetchReportWorkloadInventoryAllCSV:(reportId: number) => any;
+    fetchReportWorkloadInventoryFilteredCSV:(
+        id: number,
+        orderBy: string | undefined,
+        orderDirection: 'asc' | 'desc' | undefined,
+        filters: Map<string, string[]>
+    ) => any;
     fetchReportWorkloadInventoryAvailableFilters: (reportId: number) => any;
 }
 
@@ -109,6 +117,7 @@ interface State {
     };
     filterValue: Map<FilterTypeKeyEnum, string[]>;
     secondaryFilterDropDownOpen: boolean;
+    isToolbarKebabOpen: boolean;
 };
 
 interface FilterConfig {
@@ -265,7 +274,8 @@ class WorkloadInventory extends React.Component<Props, State> {
                 name: 'Filter',
                 value: FilterTypeKeyEnum.NONE,
             },
-            filterValue: new Map()
+            filterValue: new Map(),
+            isToolbarKebabOpen: false
         };
     }
 
@@ -274,9 +284,38 @@ class WorkloadInventory extends React.Component<Props, State> {
         this.refreshFilters();
     }
 
-    public handleDownloadCSV = () => {
-        const {reportId, fetchReportWorkloadInventoryCSV} = this.props;
-        fetchReportWorkloadInventoryCSV(reportId).then((response: any) => {
+    public handleToolbarKebabToggle = (newIsOpen: boolean) => {
+        this.setState({ isToolbarKebabOpen: newIsOpen });
+    };
+
+    public handleDownloadFilteredCSV = () => {
+        this.handleToolbarKebabToggle(false);
+
+        const { sortBy, filterValue, } = this.state;
+        const {reportId, fetchReportWorkloadInventoryFilteredCSV} = this.props;
+
+        const orderByColumn = sortBy.index ? this.state.columns[sortBy.index-1].key : undefined;
+        const orderDirection = sortBy.direction ? sortBy.direction : undefined;
+        
+        fetchReportWorkloadInventoryFilteredCSV(reportId, orderByColumn, orderDirection, filterValue).then((response: any) => {
+            const contentDispositionHeader = response.value.headers['content-disposition'];
+            const fileName = extractFilenameFromContentDispositionHeaderValue(contentDispositionHeader);
+
+            const downloadUrl = window.URL.createObjectURL(new Blob([response.value.data]));
+            const link = document.createElement('a');
+            link.href = downloadUrl;
+            link.setAttribute('download', fileName || 'workloadInventoryReport.csv');
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+        });
+    };
+
+    public handleDownloadAllCSV = () => {
+        this.handleToolbarKebabToggle(false);
+        
+        const {reportId, fetchReportWorkloadInventoryAllCSV} = this.props;
+        fetchReportWorkloadInventoryAllCSV(reportId).then((response: any) => {
             const contentDispositionHeader = response.value.headers['content-disposition'];
             const fileName = extractFilenameFromContentDispositionHeaderValue(contentDispositionHeader);
 
@@ -303,11 +342,11 @@ class WorkloadInventory extends React.Component<Props, State> {
     ) => {
         const { reportId, fetchReportWorkloadInventory } = this.props;
 
-        const column = index ? this.state.columns[index-1].key : undefined;
+        const orderByColumn = index ? this.state.columns[index-1].key : undefined;
         const orderDirection = direction ? direction : undefined;
 
         const mappedFilterValue = this.prepareFiltersToBeSended(filterValue);
-        fetchReportWorkloadInventory(reportId, page, perPage, column, orderDirection, mappedFilterValue).then(() => {
+        fetchReportWorkloadInventory(reportId, page, perPage, orderByColumn, orderDirection, mappedFilterValue).then(() => {
             this.filtersInRowsAndCells();
         });
     };
@@ -896,7 +935,12 @@ class WorkloadInventory extends React.Component<Props, State> {
     };
 
     public render() {
-        const { reportWorkloadInventoryFetchStatus, reportWorkloadInventoryCSVFetchStatus } = this.props;
+        const { isToolbarKebabOpen } = this.state;
+        const {
+            reportWorkloadInventoryFetchStatus,
+            reportWorkloadInventoryAllCSVFetchStatus,
+            reportWorkloadInventoryFilteredCSVFetchStatus
+        } = this.props;
 
         if (reportWorkloadInventoryFetchStatus.error) {
             return this.renderFetchError();
@@ -911,16 +955,24 @@ class WorkloadInventory extends React.Component<Props, State> {
                         <ToolbarItem>{this.renderFilterTypeDropdown()}</ToolbarItem>
                         <ToolbarItem className="pf-u-mr-md">{this.renderFilterInput()}</ToolbarItem>
                         <ToolbarItem className="pf-u-mr-md">
-                            <Button
-                                variant={"primary"}
-                                onClick={this.handleDownloadCSV}
-                                isDisabled={reportWorkloadInventoryCSVFetchStatus.status==='inProgress'}
-                            >
-                                {
-                                    reportWorkloadInventoryCSVFetchStatus.status==='inProgress' ?
-                                        'Exporting CSV' : 'Export as CSV'
-                                }
-                            </Button>
+                        <Dropdown
+                            position={'right'}
+                            toggle={<KebabToggle onToggle={this.handleToolbarKebabToggle} />}
+                            isOpen={isToolbarKebabOpen}
+                            isPlain={true}
+                            dropdownItems={[
+                                <DropdownItem key="exportAsCSVAll" component="button" onClick={this.handleDownloadFilteredCSV}>
+                                    Export as CSV
+                                </DropdownItem>,
+                                <DropdownItem key="exportAsCSVFiltered" component="button" onClick={this.handleDownloadAllCSV}>
+                                    Export all as CSV
+                                </DropdownItem>
+                            ]}
+                            disabled={
+                                reportWorkloadInventoryAllCSVFetchStatus.status==='inProgress' ||
+                                reportWorkloadInventoryFilteredCSVFetchStatus.status==='inProgress'
+                            }
+                        />
                         </ToolbarItem>
                     </ToolbarGroup>
                     <ToolbarGroup>

--- a/src/pages/ReportView/WorkloadInventory/index.tsx
+++ b/src/pages/ReportView/WorkloadInventory/index.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: GlobalState) => {
 
 const mapDispatchToProps = {
     fetchReportWorkloadInventory: reportActions.fetchReportWorkloadInventory,
-    fetchReportWorkloadInventoryCSV: reportActions.fetchReportWorkloadInventoryAllCSV,
+    fetchReportWorkloadInventoryAllCSV: reportActions.fetchReportWorkloadInventoryAllCSV,
     fetchReportWorkloadInventoryFilteredCSV: reportActions.fetchReportWorkloadInventoryFilteredCSV,
     fetchReportWorkloadInventoryAvailableFilters: reportActions.fetchReportWorkloadInventoryAvailableFilters
 };

--- a/src/pages/ReportView/WorkloadInventory/index.tsx
+++ b/src/pages/ReportView/WorkloadInventory/index.tsx
@@ -8,14 +8,16 @@ const mapStateToProps = (state: GlobalState) => {
     const {
         reportWorkloadInventory,
         reportWorkloadInventoryFetchStatus,
-        reportWorkloadInventoryCSVFetchStatus,
+        reportWorkloadInventoryAllCSVFetchStatus,
+        reportWorkloadInventoryFilteredCSVFetchStatus,
         reportWorkloadInventoryAvailableFilters,
         reportWorkloadInventoryAvailableFiltersFetchStatus
     } = state.reportState;
     return {
         reportWorkloadInventory,
         reportWorkloadInventoryFetchStatus,
-        reportWorkloadInventoryCSVFetchStatus,
+        reportWorkloadInventoryAllCSVFetchStatus,
+        reportWorkloadInventoryFilteredCSVFetchStatus,
         reportWorkloadInventoryAvailableFilters,
         reportWorkloadInventoryAvailableFiltersFetchStatus
     };
@@ -23,7 +25,8 @@ const mapStateToProps = (state: GlobalState) => {
 
 const mapDispatchToProps = {
     fetchReportWorkloadInventory: reportActions.fetchReportWorkloadInventory,
-    fetchReportWorkloadInventoryCSV: reportActions.fetchReportWorkloadInventoryCSV,
+    fetchReportWorkloadInventoryCSV: reportActions.fetchReportWorkloadInventoryAllCSV,
+    fetchReportWorkloadInventoryFilteredCSV: reportActions.fetchReportWorkloadInventoryFilteredCSV,
     fetchReportWorkloadInventoryAvailableFilters: reportActions.fetchReportWorkloadInventoryAvailableFilters
 };
 

--- a/src/reducers/ReportsReducer.test.tsx
+++ b/src/reducers/ReportsReducer.test.tsx
@@ -61,7 +61,8 @@ const reportTestInitialState: ReportState = {
         items: []
     },
     reportWorkloadInventoryFetchStatus: { ...defaultFetchStatus },
-    reportWorkloadInventoryCSVFetchStatus: { ...defaultFetchStatus },
+    reportWorkloadInventoryAllCSVFetchStatus: { ...defaultFetchStatus },
+    reportWorkloadInventoryFilteredCSVFetchStatus: { ...defaultFetchStatus },
     reportWorkloadInventoryAvailableFilters: null,
     reportWorkloadInventoryAvailableFiltersFetchStatus: { ...defaultFetchStatus }
 };

--- a/src/reducers/ReportsReducer.tsx
+++ b/src/reducers/ReportsReducer.tsx
@@ -53,7 +53,10 @@ export const initialState: ReportState = {
     reportWorkloadInventoryFetchStatus: {
         ...defaultFetchStatus
     },
-    reportWorkloadInventoryCSVFetchStatus: {
+    reportWorkloadInventoryAllCSVFetchStatus: {
+        ...defaultFetchStatus
+    },
+    reportWorkloadInventoryFilteredCSVFetchStatus: {
         ...defaultFetchStatus
     },
     reportWorkloadInventoryAvailableFilters: null,
@@ -397,12 +400,12 @@ export const reportsReducer = (state: ReportState = initialState, action: Generi
             return nextState;
         }
 
-        // FETCH_REPORT_WOKLOAD_INVENTORY_CSV single report
-        case pendingMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_CSV): {
+        // FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV single report
+        case pendingMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV): {
             const nextState: ReportState = {
                 ...state,
-                reportWorkloadInventoryCSVFetchStatus: {
-                    ...state.reportWorkloadInventoryCSVFetchStatus,
+                reportWorkloadInventoryAllCSVFetchStatus: {
+                    ...state.reportWorkloadInventoryAllCSVFetchStatus,
                     error: null,
                     status: 'inProgress'
                 }
@@ -411,11 +414,11 @@ export const reportsReducer = (state: ReportState = initialState, action: Generi
             return nextState;
         }
 
-        case successMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_CSV): {
+        case successMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV): {
             const nextState: ReportState = {
                 ...state,
-                reportWorkloadInventoryCSVFetchStatus: {
-                    ...state.reportWorkloadInventoryCSVFetchStatus,
+                reportWorkloadInventoryAllCSVFetchStatus: {
+                    ...state.reportWorkloadInventoryAllCSVFetchStatus,
                     error: null,
                     status: 'complete'
                 }
@@ -423,11 +426,49 @@ export const reportsReducer = (state: ReportState = initialState, action: Generi
             return nextState;
         }
 
-        case failureMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_CSV): {
+        case failureMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_ALL_CSV): {
             const nextState: ReportState = {
                 ...state,
-                reportWorkloadInventoryCSVFetchStatus: {
-                    ...state.reportWorkloadInventoryCSVFetchStatus,
+                reportWorkloadInventoryAllCSVFetchStatus: {
+                    ...state.reportWorkloadInventoryAllCSVFetchStatus,
+                    error: action.payload.message,
+                    status: 'complete'
+                }
+            };
+            return nextState;
+        }
+
+        // FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV single report
+        case pendingMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV): {
+            const nextState: ReportState = {
+                ...state,
+                reportWorkloadInventoryFilteredCSVFetchStatus: {
+                    ...state.reportWorkloadInventoryFilteredCSVFetchStatus,
+                    error: null,
+                    status: 'inProgress'
+                }
+            };
+
+            return nextState;
+        }
+
+        case successMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV): {
+            const nextState: ReportState = {
+                ...state,
+                reportWorkloadInventoryFilteredCSVFetchStatus: {
+                    ...state.reportWorkloadInventoryFilteredCSVFetchStatus,
+                    error: null,
+                    status: 'complete'
+                }
+            };
+            return nextState;
+        }
+
+        case failureMessage(ActionTypes.FETCH_REPORT_WOKLOAD_INVENTORY_FILTERED_CSV): {
+            const nextState: ReportState = {
+                ...state,
+                reportWorkloadInventoryFilteredCSVFetchStatus: {
+                    ...state.reportWorkloadInventoryFilteredCSVFetchStatus,
                     error: action.payload.message,
                     status: 'complete'
                 }


### PR DESCRIPTION
https://jira.coreos.com/browse/MIGENG-279

Changed the "Workload migration inventory" page and added a Kebab dropdown button with options:
- Download all as CSV (Download a CSV of all data related to this report)
- Download as CSV (Download a CSV using the filters applied on the page)

![Screenshot from 2019-11-06 14-45-26](https://user-images.githubusercontent.com/2582866/68303403-1b3f6f00-00a4-11ea-9de1-495bb7f89a44.png)
