### PR TITLE
MIGENG-269: Different "ESXi hypervisors (2-socket servers)" count in CF MA UI vs. MA SaaS report

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   "scripts": {
     "build": "webpack --config config/prod.webpack.config.js",
     "test": "TZ=UTC jest --verbose",
+    "update:snapshots": "TZ=UTC jest -u",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint config src",
     "lint:js:fix": "eslint config src --fix",

--- a/src/PresentationalComponents/Reports/Environment/Environment.tsx
+++ b/src/PresentationalComponents/Reports/Environment/Environment.tsx
@@ -38,12 +38,12 @@ class Environment extends Component<Props, State> {
 
         const rows = [
             [
-                'ESXi hypervisors (2-socket servers)',
+                'Licenses for ESXi Hypervisors (2 socket)',
                 '',
                 isNullOrUndefined(hypervisors) ? 'Unknown' : formatNumber(hypervisors, 0)
             ],
             [
-                'ESXi hypervisors would be migrated to RH technologies',
+                'VMware licenses (2 socket) to migrated to RH technologies',
                 'Year1 (incremental)',
                 isNullOrUndefined(year1Hypervisor) ? 'Unknown' : formatNumber(year1Hypervisor, 0)
             ],

--- a/src/PresentationalComponents/Reports/Environment/__snapshots__/Environment.test.tsx.snap
+++ b/src/PresentationalComponents/Reports/Environment/__snapshots__/Environment.test.tsx.snap
@@ -25,12 +25,12 @@ exports[`Environment expect to render 1`] = `
     rows={
       Array [
         Array [
-          "ESXi hypervisors (2-socket servers)",
+          "Licenses for ESXi Hypervisors (2 socket)",
           "",
           "1",
         ],
         Array [
-          "ESXi hypervisors would be migrated to RH technologies",
+          "VMware licenses (2 socket) to migrated to RH technologies",
           "Year1 (incremental)",
           "12",
         ],
@@ -87,12 +87,12 @@ exports[`Environment expect to render using null and undefined data 1`] = `
     rows={
       Array [
         Array [
-          "ESXi hypervisors (2-socket servers)",
+          "Licenses for ESXi Hypervisors (2 socket)",
           "",
           "Unknown",
         ],
         Array [
-          "ESXi hypervisors would be migrated to RH technologies",
+          "VMware licenses (2 socket) to migrated to RH technologies",
           "Year1 (incremental)",
           "Unknown",
         ],
@@ -149,12 +149,12 @@ exports[`Environment expect to render using null and undefined data 2`] = `
     rows={
       Array [
         Array [
-          "ESXi hypervisors (2-socket servers)",
+          "Licenses for ESXi Hypervisors (2 socket)",
           "",
           "Unknown",
         ],
         Array [
-          "ESXi hypervisors would be migrated to RH technologies",
+          "VMware licenses (2 socket) to migrated to RH technologies",
           "Year1 (incremental)",
           "Unknown",
         ],
@@ -211,12 +211,12 @@ exports[`Environment expect to render using values equal to 0 1`] = `
     rows={
       Array [
         Array [
-          "ESXi hypervisors (2-socket servers)",
+          "Licenses for ESXi Hypervisors (2 socket)",
           "",
           "0",
         ],
         Array [
-          "ESXi hypervisors would be migrated to RH technologies",
+          "VMware licenses (2 socket) to migrated to RH technologies",
           "Year1 (incremental)",
           "0",
         ],


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-269

Changes in the initial saving estimation report:
- "ESXi hypervisors (2-socket servers)" to "Licenses for ESXi Hypervisors (2 socket)"
- "ESXi hypervisors would be migrated to RH technologies" for "VMware licenses (2 socket) to migrated to RH technologies"

![Screenshot from 2019-12-18 11-25-04](https://user-images.githubusercontent.com/2582866/71078211-30bab500-2189-11ea-8e75-e2ffccdb520f.png)
