### PR TITLE
MIGENG-173: UI Upload Form: Default “Report Name” should not include the extension of the file

### DIFF
--- a/src/Utilities/extractUtils.test.tsx
+++ b/src/Utilities/extractUtils.test.tsx
@@ -1,0 +1,21 @@
+import { getFilenameWithoutExtensions } from './extractUtils';
+
+describe('Utils', () => {
+    it('expect to remove .zip extension', () => {
+        const filename = 'myFilename.zip';
+        const filenameWithoutExtension = getFilenameWithoutExtensions(filename);
+        expect(filenameWithoutExtension).toEqual('myFilename');
+    });
+
+    it('expect to remove .tar.gz extension', () => {
+        const filename = 'myFilename.tar.gz';
+        const filenameWithoutExtension = getFilenameWithoutExtensions(filename);
+        expect(filenameWithoutExtension).toEqual('myFilename');
+    });
+
+    it('expect to remove any extension', () => {
+        const filename = 'myFilename.extension1.extension2';
+        const filenameWithoutExtension = getFilenameWithoutExtensions(filename);
+        expect(filenameWithoutExtension).toEqual('myFilename');
+    });
+});

--- a/src/Utilities/extractUtils.tsx
+++ b/src/Utilities/extractUtils.tsx
@@ -10,3 +10,7 @@ export const extractFilenameFromContentDispositionHeaderValue = (disposition: st
 
     return filename;
 };
+
+export const getFilenameWithoutExtensions = (filename: string) => {
+    return filename.replace(/(\.[^/.]+)+$/, "");
+};

--- a/src/pages/ReportsUpload/UploadForm.tsx
+++ b/src/pages/ReportsUpload/UploadForm.tsx
@@ -52,7 +52,7 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
             setTimeout(() => {
                 this.props.setFieldValue('file', file);
                 if (!this.props.values.reportName) {
-                    const fileNameWithoutExtension = file.name.replace(/\.[^/.]+$/, "");
+                    const fileNameWithoutExtension = file.name.replace(/(\.[^/.]+)+$/, "");
                     this.props.setFieldValue('reportName', fileNameWithoutExtension);
                 }
             }, 0);

--- a/src/pages/ReportsUpload/UploadForm.tsx
+++ b/src/pages/ReportsUpload/UploadForm.tsx
@@ -17,6 +17,7 @@ import {
 } from '@patternfly/react-core';
 import Dropzone from 'react-dropzone';
 import './UploadForm.scss';
+import { getFilenameWithoutExtensions } from '../../Utilities/extractUtils';
 
 export interface UploadFormProps extends FormikState<FormikValues>, FormikHandlers {
     file: File | null;
@@ -52,7 +53,7 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
             setTimeout(() => {
                 this.props.setFieldValue('file', file);
                 if (!this.props.values.reportName) {
-                    const fileNameWithoutExtension = file.name.replace(/(\.[^/.]+)+$/, "");
+                    const fileNameWithoutExtension = getFilenameWithoutExtensions(file.name);
                     this.props.setFieldValue('reportName', fileNameWithoutExtension);
                 }
             }, 0);


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-173

Remove all the extensions of a file and show it in the `Report Name` field of the Upload Form page. E.g.
- Filename = "myFile.json", then `Report Name`=myFile
- Filename = "myFile.tar.gz", then `Report Name`=myFile
- Filename = "myFile.whatever.tar.gz", then `Report Name`=myFile