### PR TITLE
MIGENG-269: Different "ESXi hypervisors (2-socket servers)" count in CF MA UI vs. MA SaaS report

### DIFF
--- a/src/PresentationalComponents/Reports/Environment/Environment.tsx
+++ b/src/PresentationalComponents/Reports/Environment/Environment.tsx
@@ -43,7 +43,7 @@ class Environment extends Component<Props, State> {
                 isNullOrUndefined(hypervisors) ? 'Unknown' : formatNumber(hypervisors, 0)
             ],
             [
-                'VMware licenses (2 socket) to migrated to RH technologies',
+                'VMware licenses (2 socket) to migrate to RH technologies',
                 'Year1 (incremental)',
                 isNullOrUndefined(year1Hypervisor) ? 'Unknown' : formatNumber(year1Hypervisor, 0)
             ],

--- a/src/PresentationalComponents/Reports/Environment/__snapshots__/Environment.test.tsx.snap
+++ b/src/PresentationalComponents/Reports/Environment/__snapshots__/Environment.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Environment expect to render 1`] = `
           "1",
         ],
         Array [
-          "VMware licenses (2 socket) to migrated to RH technologies",
+          "VMware licenses (2 socket) to migrate to RH technologies",
           "Year1 (incremental)",
           "12",
         ],
@@ -92,7 +92,7 @@ exports[`Environment expect to render using null and undefined data 1`] = `
           "Unknown",
         ],
         Array [
-          "VMware licenses (2 socket) to migrated to RH technologies",
+          "VMware licenses (2 socket) to migrate to RH technologies",
           "Year1 (incremental)",
           "Unknown",
         ],
@@ -154,7 +154,7 @@ exports[`Environment expect to render using null and undefined data 2`] = `
           "Unknown",
         ],
         Array [
-          "VMware licenses (2 socket) to migrated to RH technologies",
+          "VMware licenses (2 socket) to migrate to RH technologies",
           "Year1 (incremental)",
           "Unknown",
         ],
@@ -216,7 +216,7 @@ exports[`Environment expect to render using values equal to 0 1`] = `
           "0",
         ],
         Array [
-          "VMware licenses (2 socket) to migrated to RH technologies",
+          "VMware licenses (2 socket) to migrate to RH technologies",
           "Year1 (incremental)",
           "0",
         ],


### PR DESCRIPTION
VMware licenses (2 socket) to migrated to RH technologies

To

VMware licenses (2 socket) to migrate to RH technologies