### PR TITLE
Fix error: mini-css-extract-plugin Conflicting order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,25 +1458,11 @@
       }
     },
     "@redhat-cloud-services/frontend-components-notifications": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-0.0.7.tgz",
-      "integrity": "sha512-HoRwrAKTRy41MdCy7EFL/Q5561ib+G0FF+NW+ZH/IOP3/oBtstVU+FhaSCDjTkDWYAzL7wuw2j7hDdaOWxVY8g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-1.0.2.tgz",
+      "integrity": "sha512-OYrkbRff8fYfJQ4i6DdzUjJYQTFoe9EjD01k2EjkLAaqqPLFbso9/xVuvKDYEFHIb4oy7ZpJm+dpW89zad/rdg==",
       "requires": {
-        "@redhat-cloud-services/frontend-components-utilities": "~0.0.7"
-      },
-      "dependencies": {
-        "@redhat-cloud-services/frontend-components-utilities": {
-          "version": "0.0.15",
-          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-0.0.15.tgz",
-          "integrity": "sha512-aZnDN7CiPK7MLSt+Kp9KbTGShhivk65i99RB9YQu/z0iKh6yNxjQhg/HK+/zTNha8atpr+emvPsHEu9bgY045A==",
-          "requires": {
-            "@sentry/browser": "^5.4.0",
-            "awesome-debounce-promise": "^2.1.0",
-            "axios": "^0.19.0",
-            "commander": "^2.20.0",
-            "react-content-loader": "^3.4.1"
-          }
-        }
+        "@redhat-cloud-services/frontend-components-utilities": "*"
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/react-core": "^3.136.11",
     "@patternfly/react-table": "^2.26.13",
     "@redhat-cloud-services/frontend-components": "^1.0.11",
-    "@redhat-cloud-services/frontend-components-notifications": "0.0.7",
+    "@redhat-cloud-services/frontend-components-notifications": "^1.0.2",
     "@redhat-cloud-services/frontend-components-utilities": "^1.0.0",
     "@types/jest": "^24.0.13",
     "@types/lodash": "^4.14.130",

--- a/src/PresentationalComponents/ReportViewPage/ReportViewPage.tsx
+++ b/src/PresentationalComponents/ReportViewPage/ReportViewPage.tsx
@@ -1,23 +1,22 @@
 import React, { Fragment, Component } from 'react';
-import { Redirect } from 'react-router-dom';
-import {
-    Main,
-    PageHeader,
-    PageHeaderTitle,
-    Skeleton
-} from '@redhat-cloud-services/frontend-components';
+import { Link, Redirect } from 'react-router-dom';
 import {
     Tabs,
     Tab,
     Breadcrumb,
     BreadcrumbItem
 } from '@patternfly/react-core';
+import {
+    Main,
+    PageHeader,
+    PageHeaderTitle,
+    Skeleton
+} from '@redhat-cloud-services/frontend-components';
 import { Report } from '../../models';
-import { Link } from 'react-router-dom';
 import { RouterGlobalProps } from '../../models/router';
-import { REPORT_VIEW_PATHS, DEFAULT_VIEW_PATH_INDEX, INITIAL_SAVINGS_ESTIMATION_KEY } from '../../pages/ReportView/ReportViewConstants';
 import { ObjectFetchStatus } from '../../models/state';
 import { formatDate } from '../../Utilities/formatValue';
+import { REPORT_VIEW_PATHS, DEFAULT_VIEW_PATH_INDEX, INITIAL_SAVINGS_ESTIMATION_KEY } from '../../pages/ReportView/ReportViewConstants';
 
 export interface Props extends RouterGlobalProps {
     mainStyle?: any;

--- a/src/PresentationalComponents/ReportViewPage/ReportViewPage.tsx
+++ b/src/PresentationalComponents/ReportViewPage/ReportViewPage.tsx
@@ -4,7 +4,11 @@ import {
     Tabs,
     Tab,
     Breadcrumb,
-    BreadcrumbItem
+    BreadcrumbItem,
+    Stack,
+    StackItem,
+    Grid,
+    GridItem
 } from '@patternfly/react-core';
 import {
     Main,
@@ -101,30 +105,30 @@ class ReportViewPage extends Component<Props, State> {
     public renderTabsSkeleton = () => {
         return (
             <React.Fragment>
-                <div className="pf-l-stack pf-m-gutter">
-                    <div className="pf-l-stack__item">
+                <Stack gutter="sm">
+                    <StackItem>
                         <Skeleton size="sm" />
-                    </div>
-                    <div className="pf-l-stack__item">
+                    </StackItem>
+                    <StackItem>
                         <Skeleton size="sm" />
-                    </div>
-                    <div className="pf-l-stack__item">
+                    </StackItem>
+                    <StackItem>
                         <Skeleton size="sm" />
-                    </div>
-                    <div className="pf-l-stack__item">
-                        <div className="pf-l-grid">
-                            <div className="pf-l-grid__item pf-m-4-col">
+                    </StackItem>
+                    <StackItem>
+                        <Grid>
+                            <GridItem span={4}>
                                 <Skeleton size="md" />
-                            </div>
-                            <div className="pf-l-grid__item pf-m-4-col">
+                            </GridItem>
+                            <GridItem span={4}>
                                 <Skeleton size="md" />
-                            </div>
-                            <div className="pf-l-grid__item pf-m-4-col">
+                            </GridItem>
+                            <GridItem span={4}>
                                 <Skeleton size="md" />
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                            </GridItem>
+                        </Grid>
+                    </StackItem>
+                </Stack>
             </React.Fragment>
         );
     };

--- a/src/PresentationalComponents/ReportViewPage/__snapshots__/ReportViewPage.test.tsx.snap
+++ b/src/PresentationalComponents/ReportViewPage/__snapshots__/ReportViewPage.test.tsx.snap
@@ -13,66 +13,56 @@ exports[`ReportViewPage expect to render skeleton 1`] = `
     <PageHeaderTitle
       title={
         <React.Fragment>
-          <div
-            className="pf-l-stack pf-m-gutter"
+          <Stack
+            gutter="sm"
           >
-            <div
-              className="pf-l-stack__item"
-            >
+            <StackItem>
               <Skeleton
                 isDark={false}
                 size="sm"
               />
-            </div>
-            <div
-              className="pf-l-stack__item"
-            >
+            </StackItem>
+            <StackItem>
               <Skeleton
                 isDark={false}
                 size="sm"
               />
-            </div>
-            <div
-              className="pf-l-stack__item"
-            >
+            </StackItem>
+            <StackItem>
               <Skeleton
                 isDark={false}
                 size="sm"
               />
-            </div>
-            <div
-              className="pf-l-stack__item"
-            >
-              <div
-                className="pf-l-grid"
-              >
-                <div
-                  className="pf-l-grid__item pf-m-4-col"
+            </StackItem>
+            <StackItem>
+              <Grid>
+                <GridItem
+                  span={4}
                 >
                   <Skeleton
                     isDark={false}
                     size="md"
                   />
-                </div>
-                <div
-                  className="pf-l-grid__item pf-m-4-col"
+                </GridItem>
+                <GridItem
+                  span={4}
                 >
                   <Skeleton
                     isDark={false}
                     size="md"
                   />
-                </div>
-                <div
-                  className="pf-l-grid__item pf-m-4-col"
+                </GridItem>
+                <GridItem
+                  span={4}
                 >
                   <Skeleton
                     isDark={false}
                     size="md"
                   />
-                </div>
-              </div>
-            </div>
-          </div>
+                </GridItem>
+              </Grid>
+            </StackItem>
+          </Stack>
         </React.Fragment>
       }
     />

--- a/src/PresentationalComponents/ReportViewPage/index.tsx
+++ b/src/PresentationalComponents/ReportViewPage/index.tsx
@@ -1,4 +1,4 @@
-import ReportViewPage from './ReportViewPage';
 import { withRouter } from 'react-router';
+import ReportViewPage from './ReportViewPage';
 
 export default withRouter(ReportViewPage);

--- a/src/SmartComponents/DeleteDialog/DeleteDialog.tsx
+++ b/src/SmartComponents/DeleteDialog/DeleteDialog.tsx
@@ -1,5 +1,5 @@
-import { Button, Modal, ButtonVariant } from '@patternfly/react-core';
 import React from 'react';
+import { Button, Modal, ButtonVariant } from '@patternfly/react-core';
 import './DeleteDialog.scss';
 
 interface Props {

--- a/src/SmartComponents/Reports/FlagsTable/FlagsTable.tsx
+++ b/src/SmartComponents/Reports/FlagsTable/FlagsTable.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import {
-    TableToolbar,
-    SkeletonTable
-} from '@redhat-cloud-services/frontend-components';
+    Pagination,
+    Bullseye,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    Title,
+    EmptyStateBody
+} from '@patternfly/react-core';
 import {
     Table,
     TableHeader,
@@ -14,22 +19,17 @@ import {
     cellWidth,
     TableVariant
 } from '@patternfly/react-table';
-import {
-    Pagination,
-    Bullseye,
-    EmptyState,
-    EmptyStateIcon,
-    EmptyStateVariant,
-    Title,
-    EmptyStateBody} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import {
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
+import debounce from 'lodash/debounce';
 import { FlagModel, FlagAssessmentModel } from '../../../models';
 import { ObjectFetchStatus } from '../../../models/state';
-import debounce from 'lodash/debounce';
 import { formatNumber } from '../../../Utilities/formatValue';
-import './FlagsTable.scss';
 import { isNullOrUndefined } from '../../../Utilities/formUtils';
 import { FetchErrorEmptyState } from '../../../PresentationalComponents/FetchErrorEmptyState';
+import './FlagsTable.scss';
 
 interface StateToProps {
     reportFlags: {

--- a/src/SmartComponents/Reports/WorkloadsDetectedTable/WorkloadsDetectedTable.tsx
+++ b/src/SmartComponents/Reports/WorkloadsDetectedTable/WorkloadsDetectedTable.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import {
-    TableToolbar,
-    SkeletonTable
-} from '@redhat-cloud-services/frontend-components';
+    Pagination,
+    Bullseye,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    Title,
+    EmptyStateBody
+} from '@patternfly/react-core';
 import {
     Table,
     TableHeader,
@@ -14,22 +19,17 @@ import {
     cellWidth,
     TableVariant
 } from '@patternfly/react-table';
-import {
-    Pagination,
-    Bullseye,
-    EmptyState,
-    EmptyStateIcon,
-    EmptyStateVariant,
-    Title,
-    EmptyStateBody} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import {
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
+import debounce from 'lodash/debounce';
 import { WorkloadModel } from '../../../models';
 import { ObjectFetchStatus } from '../../../models/state';
-import debounce from 'lodash/debounce';
 import { formatNumber } from '../../../Utilities/formatValue';
-import './WorkloadsDetectedTable.scss';
 import { isNullOrUndefined } from '../../../Utilities/formUtils';
 import { FetchErrorEmptyState } from '../../../PresentationalComponents/FetchErrorEmptyState';
+import './WorkloadsDetectedTable.scss';
 
 interface StateToProps {
     reportWorkloadsDetected: {

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-    Main,
-    PageHeader,
-    PageHeaderTitle
-} from '@redhat-cloud-services/frontend-components';
+import { Link } from 'react-router-dom';
 import {
     Bullseye,
     EmptyState,
@@ -14,7 +10,11 @@ import {
     EmptyStateBody
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon } from '@patternfly/react-icons';
-import { Link } from 'react-router-dom';
+import {
+    Main,
+    PageHeader,
+    PageHeaderTitle
+} from '@redhat-cloud-services/frontend-components';
 
 interface StateToProps {}
 

--- a/src/pages/GettingStarted/GettingStarted.tsx
+++ b/src/pages/GettingStarted/GettingStarted.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Redirect, Link } from 'react-router-dom';
 import {
     EmptyStateBody,
     EmptyState,
@@ -7,11 +7,10 @@ import {
     Bullseye,
     EmptyStateVariant
 } from '@patternfly/react-core';
-import ProcessImprovementSvg from '../../PresentationalComponents/Icons/process-improvement_svg';
-import './GettingStarted.scss';
-import ReportsPage from '../../PresentationalComponents/ReportsPage/ReportsPage';
 import { User } from '../../models';
-import { Redirect } from 'react-router';
+import ProcessImprovementSvg from '../../PresentationalComponents/Icons/process-improvement_svg';
+import ReportsPage from '../../PresentationalComponents/ReportsPage/ReportsPage';
+import './GettingStarted.scss';
 
 interface StateToProps {
     user: User | null;

--- a/src/pages/NoReports/NoReports.tsx
+++ b/src/pages/NoReports/NoReports.tsx
@@ -9,11 +9,11 @@ import {
     Bullseye,
     TitleLevel
 } from '@patternfly/react-core';
-import ReportsPage from '../../PresentationalComponents/ReportsPage';
 import {
     AddCircleOIcon
 } from '@patternfly/react-icons';
 import { User } from '../../models';
+import ReportsPage from '../../PresentationalComponents/ReportsPage';
 
 interface StateToProps {
     user: User | null;

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
 import {
-    Skeleton,
-    SkeletonTable
-} from '@redhat-cloud-services/frontend-components';
-import {
     Card,
     CardBody,
     CardHeader,
@@ -19,6 +15,18 @@ import {
     Button,
     Tooltip
 } from '@patternfly/react-core';
+import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
+import {
+    ChartAxisProps,
+    ChartLegendProps,
+    ChartProps,
+    ChartGroupProps,
+    ChartBarProps
+} from '@patternfly/react-charts';
+import {
+    Skeleton,
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
 
 import { Report, ReportInitialSavingEstimation } from '../../../models';
 import { formatValue } from '../../../Utilities/formatValue';
@@ -31,14 +39,6 @@ import FancyGroupedBarChart from '../../../PresentationalComponents/FancyGrouped
 import ReportCard from '../../../PresentationalComponents/ReportCard';
 import ProjectCostBreakdownTable from '../../../PresentationalComponents/Reports/ProjectCostBreakdownTable';
 import { ObjectFetchStatus } from '../../../models/state';
-import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
-import {
-    ChartAxisProps,
-    ChartLegendProps,
-    ChartProps,
-    ChartGroupProps,
-    ChartBarProps
-} from '@patternfly/react-charts';
 import { FancyChartDonutData } from '../../../PresentationalComponents/FancyChartDonut/FancyChartDonut';
 
 interface StateToProps {

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -13,7 +13,9 @@ import {
     TitleLevel,
     EmptyStateBody,
     Button,
-    Tooltip
+    Tooltip,
+    Grid,
+    GridItem
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
 import {
@@ -429,22 +431,34 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                         { this.renderInfo() }
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">
-                            { this.renderCostExpenditureComparison() }
-                            { this.renderEnvironment() }
-                        </div>
+                        <Grid gutter="sm" lg={6}>
+                            <GridItem>
+                                { this.renderCostExpenditureComparison() }
+                            </GridItem>
+                            <GridItem>
+                                { this.renderEnvironment() }
+                            </GridItem>
+                        </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">
-                            { this.renderTotalMaintenance() }
-                            { this.renderRenewalEstimation() }
-                        </div>
+                        <Grid gutter="sm" lg={6}>
+                            <GridItem>
+                                { this.renderTotalMaintenance() }
+                            </GridItem>
+                            <GridItem>
+                                { this.renderRenewalEstimation() }
+                            </GridItem>
+                        </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">
-                            { this.renderProjectCostBreakdown() }
-                            { this.renderProjectCostBreakdownTable() }
-                        </div>
+                        <Grid gutter="sm" lg={6}>
+                            <GridItem>
+                                { this.renderProjectCostBreakdown() }
+                            </GridItem>
+                            <GridItem>
+                                { this.renderProjectCostBreakdownTable() }
+                            </GridItem>
+                        </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
                         <Card>
@@ -481,46 +495,58 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                         </ReportCard>
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">
-                            <ReportCard
-                                title={ <Skeleton size="sm" /> }
-                            >
-                                <Skeleton size="sm" style={ { height: '300px' } }/>
-                            </ReportCard>
-                            <ReportCard
-                                title={ <Skeleton size="sm" /> }
-                            >
-                                <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
-                            </ReportCard>
-                        </div>
+                        <Grid lg={6} gutter="sm">
+                            <GridItem>
+                                <ReportCard
+                                    title={ <Skeleton size="sm" /> }
+                                >
+                                    <Skeleton size="sm" style={ { height: '300px' } }/>
+                                </ReportCard>
+                            </GridItem>
+                            <GridItem>
+                                <ReportCard
+                                    title={ <Skeleton size="sm" /> }
+                                >
+                                    <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
+                                </ReportCard>
+                            </GridItem>
+                        </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">
-                            <ReportCard
-                                title={ <Skeleton size="sm" /> }
-                            >
-                                <Skeleton size="sm" style={ { height: '300px' } }/>
-                            </ReportCard>
-                            <ReportCard
-                                title={ <Skeleton size="sm" /> }
-                            >
-                                <SkeletonTable colSize={ 2 } rowSize={ 2 }/>
-                            </ReportCard>
-                        </div>
+                        <Grid lg={6} gutter="sm">
+                            <GridItem>
+                                <ReportCard
+                                    title={ <Skeleton size="sm" /> }
+                                >
+                                    <Skeleton size="sm" style={ { height: '300px' } }/>
+                                </ReportCard>
+                            </GridItem>
+                            <GridItem>
+                                <ReportCard
+                                    title={ <Skeleton size="sm" /> }
+                                >
+                                    <SkeletonTable colSize={ 2 } rowSize={ 2 }/>
+                                </ReportCard>
+                            </GridItem>
+                        </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">
-                            <ReportCard
-                                title={ <Skeleton size="sm" /> }
-                            >
-                                <Skeleton size="sm" style={ { height: '300px' } }/>
-                            </ReportCard>
-                            <ReportCard
-                                title={ <Skeleton size="sm" /> }
-                            >
-                                <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
-                            </ReportCard>
-                        </div>
+                        <Grid lg={6} gutter="sm">
+                            <GridItem>
+                                <ReportCard
+                                    title={ <Skeleton size="sm" /> }
+                                >
+                                    <Skeleton size="sm" style={ { height: '300px' } }/>
+                                </ReportCard>
+                            </GridItem>
+                            <GridItem>
+                                <ReportCard
+                                    title={ <Skeleton size="sm" /> }
+                                >
+                                    <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
+                                </ReportCard>
+                            </GridItem>
+                        </Grid>
                     </StackItem>
                 </Stack>
             </React.Fragment>

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -14,8 +14,7 @@ import {
     EmptyStateBody,
     Button,
     Tooltip,
-    Grid,
-    GridItem
+    Grid
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
 import {
@@ -431,33 +430,22 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                         { this.renderInfo() }
                     </StackItem>
                     <StackItem isFilled={ false }>
+                        {/* Use Grid without GridItem to fill the height of panel */}
                         <Grid gutter="sm" lg={6}>
-                            <GridItem>
-                                { this.renderCostExpenditureComparison() }
-                            </GridItem>
-                            <GridItem>
-                                { this.renderEnvironment() }
-                            </GridItem>
+                            { this.renderCostExpenditureComparison() }
+                            { this.renderEnvironment() }
                         </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
                         <Grid gutter="sm" lg={6}>
-                            <GridItem>
-                                { this.renderTotalMaintenance() }
-                            </GridItem>
-                            <GridItem>
-                                { this.renderRenewalEstimation() }
-                            </GridItem>
+                            { this.renderTotalMaintenance() }
+                            { this.renderRenewalEstimation() }
                         </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
                         <Grid gutter="sm" lg={6}>
-                            <GridItem>
-                                { this.renderProjectCostBreakdown() }
-                            </GridItem>
-                            <GridItem>
-                                { this.renderProjectCostBreakdownTable() }
-                            </GridItem>
+                            { this.renderProjectCostBreakdown() }
+                            { this.renderProjectCostBreakdownTable() }
                         </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
@@ -496,56 +484,44 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                     </StackItem>
                     <StackItem isFilled={ false }>
                         <Grid lg={6} gutter="sm">
-                            <GridItem>
-                                <ReportCard
-                                    title={ <Skeleton size="sm" /> }
-                                >
-                                    <Skeleton size="sm" style={ { height: '300px' } }/>
-                                </ReportCard>
-                            </GridItem>
-                            <GridItem>
-                                <ReportCard
-                                    title={ <Skeleton size="sm" /> }
-                                >
-                                    <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
-                                </ReportCard>
-                            </GridItem>
+                            <ReportCard
+                                title={ <Skeleton size="sm" /> }
+                            >
+                                <Skeleton size="sm" style={ { height: '300px' } }/>
+                            </ReportCard>                            
+                            <ReportCard
+                                title={ <Skeleton size="sm" /> }
+                            >
+                                <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
+                            </ReportCard>
                         </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
                         <Grid lg={6} gutter="sm">
-                            <GridItem>
-                                <ReportCard
-                                    title={ <Skeleton size="sm" /> }
-                                >
-                                    <Skeleton size="sm" style={ { height: '300px' } }/>
-                                </ReportCard>
-                            </GridItem>
-                            <GridItem>
-                                <ReportCard
-                                    title={ <Skeleton size="sm" /> }
-                                >
-                                    <SkeletonTable colSize={ 2 } rowSize={ 2 }/>
-                                </ReportCard>
-                            </GridItem>
+                            <ReportCard
+                                title={ <Skeleton size="sm" /> }
+                            >
+                                <Skeleton size="sm" style={ { height: '300px' } }/>
+                            </ReportCard>
+                            <ReportCard
+                                title={ <Skeleton size="sm" /> }
+                            >
+                                <SkeletonTable colSize={ 2 } rowSize={ 2 }/>
+                            </ReportCard>
                         </Grid>
                     </StackItem>
                     <StackItem isFilled={ false }>
                         <Grid lg={6} gutter="sm">
-                            <GridItem>
-                                <ReportCard
-                                    title={ <Skeleton size="sm" /> }
-                                >
-                                    <Skeleton size="sm" style={ { height: '300px' } }/>
-                                </ReportCard>
-                            </GridItem>
-                            <GridItem>
-                                <ReportCard
-                                    title={ <Skeleton size="sm" /> }
-                                >
-                                    <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
-                                </ReportCard>
-                            </GridItem>
+                            <ReportCard
+                                title={ <Skeleton size="sm" /> }
+                            >
+                                <Skeleton size="sm" style={ { height: '300px' } }/>
+                            </ReportCard>
+                            <ReportCard
+                                title={ <Skeleton size="sm" /> }
+                            >
+                                <SkeletonTable colSize={ 3 } rowSize={ 3 }/>
+                            </ReportCard>
                         </Grid>
                     </StackItem>
                 </Stack>

--- a/src/pages/ReportView/ReportView.js
+++ b/src/pages/ReportView/ReportView.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Redirect, Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ReportViewPage from '../../PresentationalComponents/ReportViewPage';
 import { REPORT_VIEW_PATHS, DEFAULT_VIEW_PATH_INDEX } from './ReportViewConstants';
+import ReportViewPage from '../../PresentationalComponents/ReportViewPage';
 
 class ReportView extends React.Component {
 

--- a/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
+++ b/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
@@ -43,9 +43,18 @@ import {
     classNames,
     Visibility
 } from '@patternfly/react-table';
-import { ErrorCircleOIcon, SearchIcon, FilterIcon } from '@patternfly/react-icons';
-import { Formik } from 'formik';
+import {
+    ErrorCircleOIcon,
+    SearchIcon,
+    FilterIcon,
+    FlagIcon
+} from '@patternfly/react-icons';
+import {
+    TableToolbar,
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
 import debounce from 'lodash/debounce';
+import { Formik } from 'formik';
 import { RouterGlobalProps } from '../../../models/router';
 import { ReportWorkloadInventory, WorkloadInventoryReportFiltersModel } from '../../../models';
 import { ObjectFetchStatus } from '../../../models/state';

--- a/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
+++ b/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { RouterGlobalProps } from '../../../models/router';
 import {
-    TableToolbar,
-    SkeletonTable
-} from '@redhat-cloud-services/frontend-components';
-import {
     expandable,
     Table,
     TableHeader,
@@ -49,13 +45,17 @@ import {
     KebabToggle
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, SearchIcon, FilterIcon } from '@patternfly/react-icons';
-import './WorkloadInventory.scss';
-import { ReportWorkloadInventory, WorkloadInventoryReportFiltersModel } from '../../../models';
-import { ObjectFetchStatus } from '../../../models/state';
-import debounce from 'lodash/debounce';
-import { extractFilenameFromContentDispositionHeaderValue } from '../../../Utilities/extractUtils';
+import {
+    TableToolbar,
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
 import { Formik } from 'formik';
+import debounce from 'lodash/debounce';
+import { ObjectFetchStatus } from '../../../models/state';
+import { ReportWorkloadInventory, WorkloadInventoryReportFiltersModel } from '../../../models';
+import { extractFilenameFromContentDispositionHeaderValue } from '../../../Utilities/extractUtils';
 import { WorkloadInventoryDetails } from './WorkloadInventoryDetails';
+import './WorkloadInventory.scss';
 
 interface StateToProps extends RouterGlobalProps {
     reportWorkloadInventory: {

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -1,8 +1,4 @@
 import React from 'react';
-import {
-    Skeleton,
-    SkeletonTable
-} from '@redhat-cloud-services/frontend-components';
 import { ObjectFetchStatus } from '../../../models/state';
 import { ReportWorkloadSummary } from '../../../models';
 import {
@@ -19,6 +15,10 @@ import {
     Tooltip
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
+import {
+    Skeleton,
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
 import ReportCard from '../../../PresentationalComponents/ReportCard';
 import SummaryTable from '../../../PresentationalComponents/Reports/SummaryTable';
 import FancyChartDonut from '../../../PresentationalComponents/FancyChartDonut';

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -12,7 +12,9 @@ import {
     TitleLevel,
     Stack,
     StackItem,
-    Tooltip
+    Tooltip,
+    Grid,
+    GridItem
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
 import {
@@ -206,24 +208,32 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
 
         return (
             <ReportCard title={title} skipBullseye={true}>
-                <div className="pf-l-grid pf-m-all-6-col-on-md pf-m-all-3-col-on-lg pf-m-gutter">
-                    <SolidCard
-                        title={`${formatPercentage(percentages[0], 0)} RHV`}
-                        description="Workloads suitable for Red Hat Virtualization"
-                    />
-                    <SolidCard
-                        title={`${formatPercentage(percentages[1], 0)} OSP`}
-                        description="Workloads could be running on Red Hat OpenStack Platform"
-                    />
-                    <SolidCard
-                        title={`${formatPercentage(percentages[2], 0)} RHEL`}
-                        description="Workloads possible to migrate to Red Hat Enterprise Linux"
-                    />
-                    <SolidCard
-                        title={`${formatPercentage(percentages[3], 0)} OCP`}
-                        description="Workloads targeted for OpenShift virtualization"
-                    />
-                </div>
+                <Grid gutter="sm" md={6} lg={3}>
+                    <GridItem>
+                        <SolidCard
+                            title={`${formatPercentage(percentages[0], 0)} RHV`}
+                            description="Workloads suitable for Red Hat Virtualization"
+                        />
+                    </GridItem>
+                    <GridItem>
+                        <SolidCard
+                            title={`${formatPercentage(percentages[1], 0)} OSP`}
+                            description="Workloads could be running on Red Hat OpenStack Platform"
+                        />
+                    </GridItem>
+                    <GridItem>
+                        <SolidCard
+                            title={`${formatPercentage(percentages[2], 0)} RHEL`}
+                            description="Workloads possible to migrate to Red Hat Enterprise Linux"
+                        />
+                    </GridItem>
+                    <GridItem>
+                        <SolidCard
+                            title={`${formatPercentage(percentages[3], 0)} OCP`}
+                            description="Workloads targeted for OpenShift virtualization"
+                        />
+                    </GridItem>
+                </Grid>
             </ReportCard>
         );
     };

--- a/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
+++ b/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
@@ -170,26 +170,36 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
         skipBullseye={true}
         title="Target recommendation"
       >
-        <div
-          className="pf-l-grid pf-m-all-6-col-on-md pf-m-all-3-col-on-lg pf-m-gutter"
+        <Grid
+          gutter="sm"
+          lg={3}
+          md={6}
         >
-          <SolidCard
-            description="Workloads suitable for Red Hat Virtualization"
-            title="97% RHV"
-          />
-          <SolidCard
-            description="Workloads could be running on Red Hat OpenStack Platform"
-            title="96% OSP"
-          />
-          <SolidCard
-            description="Workloads possible to migrate to Red Hat Enterprise Linux"
-            title="6% RHEL"
-          />
-          <SolidCard
-            description="Workloads targeted for OpenShift virtualization"
-            title="88% OCP"
-          />
-        </div>
+          <GridItem>
+            <SolidCard
+              description="Workloads suitable for Red Hat Virtualization"
+              title="97% RHV"
+            />
+          </GridItem>
+          <GridItem>
+            <SolidCard
+              description="Workloads could be running on Red Hat OpenStack Platform"
+              title="96% OSP"
+            />
+          </GridItem>
+          <GridItem>
+            <SolidCard
+              description="Workloads possible to migrate to Red Hat Enterprise Linux"
+              title="6% RHEL"
+            />
+          </GridItem>
+          <GridItem>
+            <SolidCard
+              description="Workloads targeted for OpenShift virtualization"
+              title="88% OCP"
+            />
+          </GridItem>
+        </Grid>
       </ReportCard>
     </StackItem>
     <StackItem

--- a/src/pages/Reports/Reports.tsx
+++ b/src/pages/Reports/Reports.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {
-    TableToolbar,
-    SkeletonTable,
-    Skeleton
-} from '@redhat-cloud-services/frontend-components';
-import {
     Button,
     ToolbarGroup,
     ToolbarItem,
@@ -33,22 +28,25 @@ import {
     IRow,
     ICell
 } from '@patternfly/react-table';
-
-import './Reports.scss';
-import { Report } from '../../models';
-import { RouterGlobalProps } from '../../models/router';
-import ReportsPage from '../../PresentationalComponents/ReportsPage';
-import * as deleteActions from '../../actions/DialogDeleteActions';
 import {
     SearchIcon,
     OkIcon,
     ErrorCircleOIcon,
     InProgressIcon
 } from '@patternfly/react-icons';
+import {
+    TableToolbar,
+    SkeletonTable
+} from '@redhat-cloud-services/frontend-components';
 import debounce from 'lodash/debounce';
 import { Formik } from 'formik';
+import { Report } from '../../models';
+import { RouterGlobalProps } from '../../models/router';
 import { ObjectFetchStatus } from '../../models/state';
+import * as deleteActions from '../../actions/DialogDeleteActions';
 import { formatDate } from '../../Utilities/formatValue';
+import ReportsPage from '../../PresentationalComponents/ReportsPage';
+import './Reports.scss';
 
 interface StateToProps {
     reports: {

--- a/src/pages/ReportsUpload/ReportsUpload.tsx
+++ b/src/pages/ReportsUpload/ReportsUpload.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import {
     Button,
     Modal,
@@ -16,20 +17,19 @@ import {
     EmptyStateSecondaryActions
 } from '@patternfly/react-core';
 import { VolumeIcon } from '@patternfly/react-icons';
-import { Link } from 'react-router-dom';
-import Axios from 'axios';
-import { Formik } from 'formik';
-import * as Yup from 'yup';
-import { RouterGlobalProps } from '../../models/router';
 import {
     Main,
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
+import Axios from 'axios';
+import { Formik } from 'formik';
+import * as Yup from 'yup';
+import { RouterGlobalProps } from '../../models/router';
 import { Upload, User } from '../../models';
-import './ReportsUpload.scss';
-import UploadForm from './UploadForm';
 import { validateForm } from '../../Utilities/formUtils';
+import UploadForm from './UploadForm';
+import './ReportsUpload.scss';
 
 interface FormValues {
     file: File | undefined;

--- a/src/pages/ReportsUpload/UploadForm.tsx
+++ b/src/pages/ReportsUpload/UploadForm.tsx
@@ -13,7 +13,9 @@ import {
     InputGroupText,
     Stack,
     StackItem,
-    ActionGroup
+    ActionGroup,
+    Grid,
+    GridItem
 } from '@patternfly/react-core';
 import Dropzone from 'react-dropzone';
 import './UploadForm.scss';
@@ -175,27 +177,30 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                         (errors.yearOverYearGrowthRatePercentage && touched.yearOverYearGrowthRatePercentage) ? false : true
                     }
                 >
-                    <div className="pf-l-grid pf-m-all-3-col-on-md">
-                        <InputGroup>
-                            <TextInput
-                                isRequired={true}
-                                id="yearOverYearGrowthRatePercentage"
-                                type="number"
-                                name="yearOverYearGrowthRatePercentage"
-                                aria-describedby="Year-over-year growth rate for new hypervisors"
-                                className="pf-u-text-align-right"
-                                onChange={ customHandleChange }
-                                onBlur={ handleBlur }
-                                value={ values.yearOverYearGrowthRatePercentage }
-                                isValid={
-                                    (errors.yearOverYearGrowthRatePercentage && touched.yearOverYearGrowthRatePercentage) ? false : true
-                                }
-                            />
-                            <InputGroupText>%</InputGroupText>
-                        </InputGroup>
-                    </div>
+                    <Grid md={3}>
+                        <GridItem>
+                            <InputGroup>
+                                <TextInput
+                                    isRequired={true}
+                                    id="yearOverYearGrowthRatePercentage"
+                                    type="number"
+                                    name="yearOverYearGrowthRatePercentage"
+                                    aria-describedby="Year-over-year growth rate for new hypervisors"
+                                    className="pf-u-text-align-right"
+                                    onChange={ customHandleChange }
+                                    onBlur={ handleBlur }
+                                    value={ values.yearOverYearGrowthRatePercentage }
+                                    isValid={
+                                        (errors.yearOverYearGrowthRatePercentage && touched.yearOverYearGrowthRatePercentage) ? false : true
+                                    }
+                                />
+                                <InputGroupText>%</InputGroupText>
+                            </InputGroup>
+                        </GridItem>
+                    </Grid>
                 </FormGroup>
-                <Stack gutter="sm" className="pf-sm-gutter">
+                {/* Add  pf-sm-gutter manually until https://github.com/patternfly/patternfly-react/issues/4062 is solved*/}
+                <Stack gutter="lg" className="pf-sm-gutter">
                     <StackItem isFilled={ false }>
                         <label className="pf-c-form__label">
                             <span className="pf-c-form__label-text">Percentage of hypervisors migrated each year</span>
@@ -211,26 +216,28 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                                 (errors.percentageOfHypervisorsMigratedSum) ? false : true
                             }
                         >
-                            <div className="pf-l-grid pf-m-all-3-col-on-md">
-                                <InputGroup>
-                                    <TextInput
-                                        isRequired={true}
-                                        id="percentageOfHypervisorsMigratedOnYear1"
-                                        type="number"
-                                        name="percentageOfHypervisorsMigratedOnYear1"
-                                        aria-label="Percentage of hypervisors migrated on year 1"
-                                        className="pf-u-text-align-right"
-                                        onChange={ customHandleChange }
-                                        onBlur={ handleBlur }
-                                        value={ values.percentageOfHypervisorsMigratedOnYear1 }
-                                        isValid={
-                                            (errors.percentageOfHypervisorsMigratedOnYear1
-                                                && touched.percentageOfHypervisorsMigratedOnYear1) ? false : true
-                                        }
-                                    />
-                                    <InputGroupText>%</InputGroupText>
-                                </InputGroup>
-                            </div>
+                            <Grid md={3}>
+                                <GridItem>
+                                    <InputGroup>
+                                        <TextInput
+                                            isRequired={true}
+                                            id="percentageOfHypervisorsMigratedOnYear1"
+                                            type="number"
+                                            name="percentageOfHypervisorsMigratedOnYear1"
+                                            aria-label="Percentage of hypervisors migrated on year 1"
+                                            className="pf-u-text-align-right"
+                                            onChange={ customHandleChange }
+                                            onBlur={ handleBlur }
+                                            value={ values.percentageOfHypervisorsMigratedOnYear1 }
+                                            isValid={
+                                                (errors.percentageOfHypervisorsMigratedOnYear1
+                                                    && touched.percentageOfHypervisorsMigratedOnYear1) ? false : true
+                                            }
+                                        />
+                                        <InputGroupText>%</InputGroupText>
+                                    </InputGroup>
+                                </GridItem>
+                            </Grid>
                         </FormGroup>
                     </StackItem>
                     <StackItem isFilled={ false } className="upload-form-subform-margin-left">
@@ -243,26 +250,28 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                                 (errors.percentageOfHypervisorsMigratedSum) ? false : true
                             }
                         >
-                            <div className="pf-l-grid pf-m-all-3-col-on-md">
-                                <InputGroup>
-                                    <TextInput
-                                        isRequired={true}
-                                        id="percentageOfHypervisorsMigratedOnYear2"
-                                        type="number"
-                                        name="percentageOfHypervisorsMigratedOnYear2"
-                                        aria-label="Percentage of hypervisors migrated on year 2"
-                                        className="pf-u-text-align-right"
-                                        onChange={ customHandleChange }
-                                        onBlur={ handleBlur }
-                                        value={ values.percentageOfHypervisorsMigratedOnYear2 }
-                                        isValid={
-                                            (errors.percentageOfHypervisorsMigratedOnYear2
-                                                && touched.percentageOfHypervisorsMigratedOnYear2) ? false : true
-                                        }
-                                    />
-                                    <InputGroupText>%</InputGroupText>
-                                </InputGroup>
-                            </div>
+                            <Grid md={3}>
+                                <GridItem>
+                                    <InputGroup>
+                                        <TextInput
+                                            isRequired={true}
+                                            id="percentageOfHypervisorsMigratedOnYear2"
+                                            type="number"
+                                            name="percentageOfHypervisorsMigratedOnYear2"
+                                            aria-label="Percentage of hypervisors migrated on year 2"
+                                            className="pf-u-text-align-right"
+                                            onChange={ customHandleChange }
+                                            onBlur={ handleBlur }
+                                            value={ values.percentageOfHypervisorsMigratedOnYear2 }
+                                            isValid={
+                                                (errors.percentageOfHypervisorsMigratedOnYear2
+                                                    && touched.percentageOfHypervisorsMigratedOnYear2) ? false : true
+                                            }
+                                        />
+                                        <InputGroupText>%</InputGroupText>
+                                    </InputGroup>
+                                </GridItem>
+                            </Grid>
                         </FormGroup>
                     </StackItem>
                     <StackItem isFilled={ false } className="upload-form-subform-margin-left">
@@ -275,26 +284,28 @@ class UploadForm extends React.Component<UploadFormProps, { }> {
                                 (errors.percentageOfHypervisorsMigratedSum) ? false : true
                             }
                         >
-                            <div className="pf-l-grid pf-m-all-3-col-on-md">
-                                <InputGroup>
-                                    <TextInput
-                                        isRequired={true}
-                                        id="percentageOfHypervisorsMigratedOnYear3"
-                                        type="number"
-                                        name="percentageOfHypervisorsMigratedOnYear3"
-                                        aria-label="Percentage of hypervisors migrated on year 3"
-                                        className="pf-u-text-align-right"
-                                        onChange={ customHandleChange }
-                                        onBlur={ handleBlur }
-                                        value={ values.percentageOfHypervisorsMigratedOnYear3 }
-                                        isValid={
-                                            (errors.percentageOfHypervisorsMigratedOnYear3
-                                                && touched.percentageOfHypervisorsMigratedOnYear3) ? false : true
-                                        }
-                                    />
-                                    <InputGroupText>%</InputGroupText>
-                                </InputGroup>
-                            </div>
+                            <Grid md={3}>
+                                <GridItem>
+                                    <InputGroup>
+                                        <TextInput
+                                            isRequired={true}
+                                            id="percentageOfHypervisorsMigratedOnYear3"
+                                            type="number"
+                                            name="percentageOfHypervisorsMigratedOnYear3"
+                                            aria-label="Percentage of hypervisors migrated on year 3"
+                                            className="pf-u-text-align-right"
+                                            onChange={ customHandleChange }
+                                            onBlur={ handleBlur }
+                                            value={ values.percentageOfHypervisorsMigratedOnYear3 }
+                                            isValid={
+                                                (errors.percentageOfHypervisorsMigratedOnYear3
+                                                    && touched.percentageOfHypervisorsMigratedOnYear3) ? false : true
+                                            }
+                                        />
+                                        <InputGroupText>%</InputGroupText>
+                                    </InputGroup>
+                                </GridItem>
+                            </Grid>
                         </FormGroup>
                     </StackItem>
                 </Stack>

--- a/src/pages/ReportsUpload/__snapshots__/UploadForm.test.tsx.snap
+++ b/src/pages/ReportsUpload/__snapshots__/UploadForm.test.tsx.snap
@@ -57,30 +57,32 @@ exports[`UploadForm expect to render 1`] = `
     isValid={true}
     label="Year-over-year growth rate for new hypervisors"
   >
-    <div
-      className="pf-l-grid pf-m-all-3-col-on-md"
+    <Grid
+      md={3}
     >
-      <InputGroup>
-        <ForwardRef
-          aria-describedby="Year-over-year growth rate for new hypervisors"
-          className="pf-u-text-align-right"
-          id="yearOverYearGrowthRatePercentage"
-          isRequired={true}
-          isValid={true}
-          name="yearOverYearGrowthRatePercentage"
-          onBlur={[MockFunction]}
-          onChange={[Function]}
-          type="number"
-        />
-        <InputGroupText>
-          %
-        </InputGroupText>
-      </InputGroup>
-    </div>
+      <GridItem>
+        <InputGroup>
+          <ForwardRef
+            aria-describedby="Year-over-year growth rate for new hypervisors"
+            className="pf-u-text-align-right"
+            id="yearOverYearGrowthRatePercentage"
+            isRequired={true}
+            isValid={true}
+            name="yearOverYearGrowthRatePercentage"
+            onBlur={[MockFunction]}
+            onChange={[Function]}
+            type="number"
+          />
+          <InputGroupText>
+            %
+          </InputGroupText>
+        </InputGroup>
+      </GridItem>
+    </Grid>
   </FormGroup>
   <Stack
     className="pf-sm-gutter"
-    gutter="sm"
+    gutter="lg"
   >
     <StackItem
       isFilled={false}
@@ -104,26 +106,28 @@ exports[`UploadForm expect to render 1`] = `
         isValid={true}
         label="Year1"
       >
-        <div
-          className="pf-l-grid pf-m-all-3-col-on-md"
+        <Grid
+          md={3}
         >
-          <InputGroup>
-            <ForwardRef
-              aria-label="Percentage of hypervisors migrated on year 1"
-              className="pf-u-text-align-right"
-              id="percentageOfHypervisorsMigratedOnYear1"
-              isRequired={true}
-              isValid={true}
-              name="percentageOfHypervisorsMigratedOnYear1"
-              onBlur={[MockFunction]}
-              onChange={[Function]}
-              type="number"
-            />
-            <InputGroupText>
-              %
-            </InputGroupText>
-          </InputGroup>
-        </div>
+          <GridItem>
+            <InputGroup>
+              <ForwardRef
+                aria-label="Percentage of hypervisors migrated on year 1"
+                className="pf-u-text-align-right"
+                id="percentageOfHypervisorsMigratedOnYear1"
+                isRequired={true}
+                isValid={true}
+                name="percentageOfHypervisorsMigratedOnYear1"
+                onBlur={[MockFunction]}
+                onChange={[Function]}
+                type="number"
+              />
+              <InputGroupText>
+                %
+              </InputGroupText>
+            </InputGroup>
+          </GridItem>
+        </Grid>
       </FormGroup>
     </StackItem>
     <StackItem
@@ -135,26 +139,28 @@ exports[`UploadForm expect to render 1`] = `
         isValid={true}
         label="Year 2"
       >
-        <div
-          className="pf-l-grid pf-m-all-3-col-on-md"
+        <Grid
+          md={3}
         >
-          <InputGroup>
-            <ForwardRef
-              aria-label="Percentage of hypervisors migrated on year 2"
-              className="pf-u-text-align-right"
-              id="percentageOfHypervisorsMigratedOnYear2"
-              isRequired={true}
-              isValid={true}
-              name="percentageOfHypervisorsMigratedOnYear2"
-              onBlur={[MockFunction]}
-              onChange={[Function]}
-              type="number"
-            />
-            <InputGroupText>
-              %
-            </InputGroupText>
-          </InputGroup>
-        </div>
+          <GridItem>
+            <InputGroup>
+              <ForwardRef
+                aria-label="Percentage of hypervisors migrated on year 2"
+                className="pf-u-text-align-right"
+                id="percentageOfHypervisorsMigratedOnYear2"
+                isRequired={true}
+                isValid={true}
+                name="percentageOfHypervisorsMigratedOnYear2"
+                onBlur={[MockFunction]}
+                onChange={[Function]}
+                type="number"
+              />
+              <InputGroupText>
+                %
+              </InputGroupText>
+            </InputGroup>
+          </GridItem>
+        </Grid>
       </FormGroup>
     </StackItem>
     <StackItem
@@ -166,26 +172,28 @@ exports[`UploadForm expect to render 1`] = `
         isValid={true}
         label="Year 3"
       >
-        <div
-          className="pf-l-grid pf-m-all-3-col-on-md"
+        <Grid
+          md={3}
         >
-          <InputGroup>
-            <ForwardRef
-              aria-label="Percentage of hypervisors migrated on year 3"
-              className="pf-u-text-align-right"
-              id="percentageOfHypervisorsMigratedOnYear3"
-              isRequired={true}
-              isValid={true}
-              name="percentageOfHypervisorsMigratedOnYear3"
-              onBlur={[MockFunction]}
-              onChange={[Function]}
-              type="number"
-            />
-            <InputGroupText>
-              %
-            </InputGroupText>
-          </InputGroup>
-        </div>
+          <GridItem>
+            <InputGroup>
+              <ForwardRef
+                aria-label="Percentage of hypervisors migrated on year 3"
+                className="pf-u-text-align-right"
+                id="percentageOfHypervisorsMigratedOnYear3"
+                isRequired={true}
+                isValid={true}
+                name="percentageOfHypervisorsMigratedOnYear3"
+                onBlur={[MockFunction]}
+                onChange={[Function]}
+                type="number"
+              />
+              <InputGroupText>
+                %
+              </InputGroupText>
+            </InputGroup>
+          </GridItem>
+        </Grid>
       </FormGroup>
     </StackItem>
   </Stack>
@@ -270,30 +278,32 @@ exports[`UploadForm expect to render errors 1`] = `
     isValid={false}
     label="Year-over-year growth rate for new hypervisors"
   >
-    <div
-      className="pf-l-grid pf-m-all-3-col-on-md"
+    <Grid
+      md={3}
     >
-      <InputGroup>
-        <ForwardRef
-          aria-describedby="Year-over-year growth rate for new hypervisors"
-          className="pf-u-text-align-right"
-          id="yearOverYearGrowthRatePercentage"
-          isRequired={true}
-          isValid={false}
-          name="yearOverYearGrowthRatePercentage"
-          onBlur={[MockFunction]}
-          onChange={[Function]}
-          type="number"
-        />
-        <InputGroupText>
-          %
-        </InputGroupText>
-      </InputGroup>
-    </div>
+      <GridItem>
+        <InputGroup>
+          <ForwardRef
+            aria-describedby="Year-over-year growth rate for new hypervisors"
+            className="pf-u-text-align-right"
+            id="yearOverYearGrowthRatePercentage"
+            isRequired={true}
+            isValid={false}
+            name="yearOverYearGrowthRatePercentage"
+            onBlur={[MockFunction]}
+            onChange={[Function]}
+            type="number"
+          />
+          <InputGroupText>
+            %
+          </InputGroupText>
+        </InputGroup>
+      </GridItem>
+    </Grid>
   </FormGroup>
   <Stack
     className="pf-sm-gutter"
-    gutter="sm"
+    gutter="lg"
   >
     <StackItem
       isFilled={false}
@@ -318,26 +328,28 @@ exports[`UploadForm expect to render errors 1`] = `
         isValid={false}
         label="Year1"
       >
-        <div
-          className="pf-l-grid pf-m-all-3-col-on-md"
+        <Grid
+          md={3}
         >
-          <InputGroup>
-            <ForwardRef
-              aria-label="Percentage of hypervisors migrated on year 1"
-              className="pf-u-text-align-right"
-              id="percentageOfHypervisorsMigratedOnYear1"
-              isRequired={true}
-              isValid={false}
-              name="percentageOfHypervisorsMigratedOnYear1"
-              onBlur={[MockFunction]}
-              onChange={[Function]}
-              type="number"
-            />
-            <InputGroupText>
-              %
-            </InputGroupText>
-          </InputGroup>
-        </div>
+          <GridItem>
+            <InputGroup>
+              <ForwardRef
+                aria-label="Percentage of hypervisors migrated on year 1"
+                className="pf-u-text-align-right"
+                id="percentageOfHypervisorsMigratedOnYear1"
+                isRequired={true}
+                isValid={false}
+                name="percentageOfHypervisorsMigratedOnYear1"
+                onBlur={[MockFunction]}
+                onChange={[Function]}
+                type="number"
+              />
+              <InputGroupText>
+                %
+              </InputGroupText>
+            </InputGroup>
+          </GridItem>
+        </Grid>
       </FormGroup>
     </StackItem>
     <StackItem
@@ -350,26 +362,28 @@ exports[`UploadForm expect to render errors 1`] = `
         isValid={false}
         label="Year 2"
       >
-        <div
-          className="pf-l-grid pf-m-all-3-col-on-md"
+        <Grid
+          md={3}
         >
-          <InputGroup>
-            <ForwardRef
-              aria-label="Percentage of hypervisors migrated on year 2"
-              className="pf-u-text-align-right"
-              id="percentageOfHypervisorsMigratedOnYear2"
-              isRequired={true}
-              isValid={false}
-              name="percentageOfHypervisorsMigratedOnYear2"
-              onBlur={[MockFunction]}
-              onChange={[Function]}
-              type="number"
-            />
-            <InputGroupText>
-              %
-            </InputGroupText>
-          </InputGroup>
-        </div>
+          <GridItem>
+            <InputGroup>
+              <ForwardRef
+                aria-label="Percentage of hypervisors migrated on year 2"
+                className="pf-u-text-align-right"
+                id="percentageOfHypervisorsMigratedOnYear2"
+                isRequired={true}
+                isValid={false}
+                name="percentageOfHypervisorsMigratedOnYear2"
+                onBlur={[MockFunction]}
+                onChange={[Function]}
+                type="number"
+              />
+              <InputGroupText>
+                %
+              </InputGroupText>
+            </InputGroup>
+          </GridItem>
+        </Grid>
       </FormGroup>
     </StackItem>
     <StackItem
@@ -382,26 +396,28 @@ exports[`UploadForm expect to render errors 1`] = `
         isValid={false}
         label="Year 3"
       >
-        <div
-          className="pf-l-grid pf-m-all-3-col-on-md"
+        <Grid
+          md={3}
         >
-          <InputGroup>
-            <ForwardRef
-              aria-label="Percentage of hypervisors migrated on year 3"
-              className="pf-u-text-align-right"
-              id="percentageOfHypervisorsMigratedOnYear3"
-              isRequired={true}
-              isValid={true}
-              name="percentageOfHypervisorsMigratedOnYear3"
-              onBlur={[MockFunction]}
-              onChange={[Function]}
-              type="number"
-            />
-            <InputGroupText>
-              %
-            </InputGroupText>
-          </InputGroup>
-        </div>
+          <GridItem>
+            <InputGroup>
+              <ForwardRef
+                aria-label="Percentage of hypervisors migrated on year 3"
+                className="pf-u-text-align-right"
+                id="percentageOfHypervisorsMigratedOnYear3"
+                isRequired={true}
+                isValid={true}
+                name="percentageOfHypervisorsMigratedOnYear3"
+                onBlur={[MockFunction]}
+                onChange={[Function]}
+                type="number"
+              />
+              <InputGroupText>
+                %
+              </InputGroupText>
+            </InputGroup>
+          </GridItem>
+        </Grid>
       </FormGroup>
     </StackItem>
   </Stack>


### PR DESCRIPTION
The `mini-css-extract-plugin Conflicting order` error is referred in https://github.com/project-xavier/xavier-ui/pull/88 and it was caused because of the order of imports of: `@patternfly/react-core` and `@redhat-cloud-services/frontend-components`. In short words `@redhat-cloud-services/frontend-components` must be imported after any `@patternfly/react-*` import to avoid css conflicts.

This PR contains:
- Upgrade @redhat-cloud-services/frontend-components-notifications to v1.0.2
- Changed the import orders of `@patternfly/react-core` and `@redhat-cloud-services/frontend-components`
- Changed the grid class names for react components. E.g: `<div className="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter">...` by `<Grid gutter="sm" lg={6}><GridItem>...`

**Steps to see PR working:**
1. Clone the current PR
2. Execute `npm ci` to install dependencies
3. Execute `npm run build`
4. You WON'T see any warning message like in https://github.com/project-xavier/xavier-ui/pull/88
5. Open the file `dist/css/DeleteDialog~ErrorPage~GettingStarted~NoReports~ReportView~Reports~ReportsUpload.css` and search for `pf-m-all-6-col-on-lg` and should see it like in the screenshot above:

![Screenshot from 2020-04-13 11-04-34](https://user-images.githubusercontent.com/2582866/79109003-c7823180-7d77-11ea-8204-071afafcbdde.png)
