### PR TITLE
MIGENG-523: MA [RFE] Export CSV options are not clear enough

### DIFF
--- a/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
+++ b/src/pages/ReportView/WorkloadInventory/WorkloadInventory.tsx
@@ -63,7 +63,6 @@ interface StateToProps extends RouterGlobalProps {
         items: ReportWorkloadInventory[]
     };
     reportWorkloadInventoryFetchStatus: ObjectFetchStatus;
-    reportWorkloadInventoryAllCSVFetchStatus: ObjectFetchStatus;
     reportWorkloadInventoryFilteredCSVFetchStatus: ObjectFetchStatus;
     reportWorkloadInventoryAvailableFilters: WorkloadInventoryReportFiltersModel | null;
     reportWorkloadInventoryAvailableFiltersFetchStatus: ObjectFetchStatus;
@@ -78,7 +77,6 @@ interface DispatchToProps {
         orderDirection: 'asc' | 'desc' | undefined,
         filterValue: Map<string, string[]>
     ) => any;
-    fetchReportWorkloadInventoryAllCSV:(reportId: number) => any;
     fetchReportWorkloadInventoryFilteredCSV:(
         id: number,
         orderBy: string | undefined,
@@ -115,7 +113,6 @@ interface State {
     };
     filterValue: Map<FilterTypeKeyEnum, string[]>;
     secondaryFilterDropDownOpen: boolean;
-    isToolbarKebabOpen: boolean;
 };
 
 interface FilterConfig {
@@ -272,8 +269,7 @@ class WorkloadInventory extends React.Component<Props, State> {
                 name: 'Filter',
                 value: FilterTypeKeyEnum.NONE,
             },
-            filterValue: new Map(),
-            isToolbarKebabOpen: false
+            filterValue: new Map()
         };
     }
 
@@ -282,13 +278,7 @@ class WorkloadInventory extends React.Component<Props, State> {
         this.refreshFilters();
     }
 
-    public handleToolbarKebabToggle = (newIsOpen: boolean) => {
-        this.setState({ isToolbarKebabOpen: newIsOpen });
-    };
-
     public handleDownloadFilteredCSV = () => {
-        this.handleToolbarKebabToggle(false);
-
         const { sortBy, filterValue, } = this.state;
         const {reportId, fetchReportWorkloadInventoryFilteredCSV} = this.props;
 
@@ -297,24 +287,6 @@ class WorkloadInventory extends React.Component<Props, State> {
 
         const mappedFilterValue = this.prepareFiltersToBeSended(filterValue);
         fetchReportWorkloadInventoryFilteredCSV(reportId, orderByColumn, orderDirection, mappedFilterValue).then((response: any) => {
-            const contentDispositionHeader = response.value.headers['content-disposition'];
-            const fileName = extractFilenameFromContentDispositionHeaderValue(contentDispositionHeader);
-
-            const downloadUrl = window.URL.createObjectURL(new Blob([response.value.data]));
-            const link = document.createElement('a');
-            link.href = downloadUrl;
-            link.setAttribute('download', fileName || 'workloadInventoryReport.csv');
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-        });
-    };
-
-    public handleDownloadAllCSV = () => {
-        this.handleToolbarKebabToggle(false);
-
-        const {reportId, fetchReportWorkloadInventoryAllCSV} = this.props;
-        fetchReportWorkloadInventoryAllCSV(reportId).then((response: any) => {
             const contentDispositionHeader = response.value.headers['content-disposition'];
             const fileName = extractFilenameFromContentDispositionHeaderValue(contentDispositionHeader);
 
@@ -927,10 +899,9 @@ class WorkloadInventory extends React.Component<Props, State> {
     };
 
     public render() {
-        const { isToolbarKebabOpen } = this.state;
+        const { } = this.state;
         const {
             reportWorkloadInventoryFetchStatus,
-            reportWorkloadInventoryAllCSVFetchStatus,
             reportWorkloadInventoryFilteredCSVFetchStatus
         } = this.props;
 
@@ -947,24 +918,16 @@ class WorkloadInventory extends React.Component<Props, State> {
                         <ToolbarItem>{this.renderFilterTypeDropdown()}</ToolbarItem>
                         <ToolbarItem className="pf-u-mr-md">{this.renderFilterInput()}</ToolbarItem>
                         <ToolbarItem className="pf-u-mr-md">
-                        <Dropdown
-                            position={'right'}
-                            toggle={<KebabToggle onToggle={this.handleToolbarKebabToggle} />}
-                            isOpen={isToolbarKebabOpen}
-                            isPlain={true}
-                            dropdownItems={[
-                                <DropdownItem key="exportAsCSVAll" component="button" onClick={this.handleDownloadFilteredCSV}>
-                                    Export as CSV
-                                </DropdownItem>,
-                                <DropdownItem key="exportAsCSVFiltered" component="button" onClick={this.handleDownloadAllCSV}>
-                                    Export all as CSV
-                                </DropdownItem>
-                            ]}
-                            disabled={
-                                reportWorkloadInventoryAllCSVFetchStatus.status==='inProgress' ||
-                                reportWorkloadInventoryFilteredCSVFetchStatus.status==='inProgress'
-                            }
-                        />
+                            <Button
+                                variant={"primary"}
+                                onClick={this.handleDownloadFilteredCSV}
+                                isDisabled={reportWorkloadInventoryFilteredCSVFetchStatus.status==='inProgress'}
+                            >
+                                {
+                                    reportWorkloadInventoryFilteredCSVFetchStatus.status==='inProgress' ?
+                                        'Exporting CSV' : 'Export as CSV'
+                                }
+                            </Button>
                         </ToolbarItem>
                     </ToolbarGroup>
                     <ToolbarGroup>

--- a/src/pages/ReportView/WorkloadInventory/index.tsx
+++ b/src/pages/ReportView/WorkloadInventory/index.tsx
@@ -7,7 +7,6 @@ const mapStateToProps = (state: GlobalState) => {
     const {
         reportWorkloadInventory,
         reportWorkloadInventoryFetchStatus,
-        reportWorkloadInventoryAllCSVFetchStatus,
         reportWorkloadInventoryFilteredCSVFetchStatus,
         reportWorkloadInventoryAvailableFilters,
         reportWorkloadInventoryAvailableFiltersFetchStatus
@@ -15,7 +14,6 @@ const mapStateToProps = (state: GlobalState) => {
     return {
         reportWorkloadInventory,
         reportWorkloadInventoryFetchStatus,
-        reportWorkloadInventoryAllCSVFetchStatus,
         reportWorkloadInventoryFilteredCSVFetchStatus,
         reportWorkloadInventoryAvailableFilters,
         reportWorkloadInventoryAvailableFiltersFetchStatus
@@ -24,7 +22,6 @@ const mapStateToProps = (state: GlobalState) => {
 
 const mapDispatchToProps = {
     fetchReportWorkloadInventory: reportActions.fetchReportWorkloadInventory,
-    fetchReportWorkloadInventoryAllCSV: reportActions.fetchReportWorkloadInventoryAllCSV,
     fetchReportWorkloadInventoryFilteredCSV: reportActions.fetchReportWorkloadInventoryFilteredCSV,
     fetchReportWorkloadInventoryAvailableFilters: reportActions.fetchReportWorkloadInventoryAvailableFilters
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-523

Replace the current 2 options for downloading a CSV file for a single Button. The behavior of the "Export to CSV" button:
- If no filter was selected then it will download all the elements of the table regardless of the current page where the user is located.
- If any filter was selected then it will download just the elements that match the filter criteria.
- If any of the columns where sorted then the exported CSV will use the same sorting criteria, otherwise it will use the default sort order.

**Current version in CI:**
![Screenshot from 2020-04-15 19-28-05](https://user-images.githubusercontent.com/2582866/79368230-59906280-7f4f-11ea-878c-f5dea5ece1b2.png)

**Screenshot of the PR:**
![Screenshot from 2020-04-15 12-31-12](https://user-images.githubusercontent.com/2582866/79328505-70669300-7f16-11ea-9c8c-83b31f03951f.png)
