### PR TITLE
MIGENG-583 MIGENG-585: WSM Java Runtimes and Applications Platforms

### DIFF
--- a/profiles/local-frontend-and-api.js
+++ b/profiles/local-frontend-and-api.js
@@ -13,6 +13,6 @@ routes[`/beta/apps/${APP_ID}`]       = { host: `https://localhost:${FRONTEND_POR
 routes[`/apps/${APP_ID}`]            = { host: `https://localhost:${FRONTEND_PORT}` };
 
 // routes[`/api/xavier`] = { host: `http://localhost:${API_PORT}` };
-routes[`/api/xavier`] = { host: `http://analytics-integration-migration-analytics.127.0.0.1.nip.io` };
+routes[`/api/xavier`] = { host: `https://ci.cloud.redhat.com` };
 
 module.exports = { routes };

--- a/profiles/local-frontend-and-api.js
+++ b/profiles/local-frontend-and-api.js
@@ -13,6 +13,6 @@ routes[`/beta/apps/${APP_ID}`]       = { host: `https://localhost:${FRONTEND_POR
 routes[`/apps/${APP_ID}`]            = { host: `https://localhost:${FRONTEND_PORT}` };
 
 // routes[`/api/xavier`] = { host: `http://localhost:${API_PORT}` };
-routes[`/api/xavier`] = { host: `https://ci.cloud.redhat.com` };
+routes[`/api/xavier`] = { host: `http://analytics-integration-migration-analytics.127.0.0.1.nip.io` };
 
 module.exports = { routes };

--- a/src/PresentationalComponents/EmptyCard/EmptyCard.test.tsx
+++ b/src/PresentationalComponents/EmptyCard/EmptyCard.test.tsx
@@ -3,13 +3,22 @@ import { shallow } from 'enzyme';
 import { EmptyCard } from './EmptyCard';
 
 describe('EmptyCard', () => {
-    it('expect to render', () => {
-        const wrapper = shallow(<EmptyCard title="My Title" />);
+    it('expect to render without description', () => {
+        const wrapper = shallow(<EmptyCard cardTitle="My card title" message="My message" />);
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('expect to render with title as Element', () => {
-        const wrapper = shallow(<EmptyCard title={<h1>My Title</h1>} />);
+    it('expect to render with description', () => {
+        const wrapper = shallow(
+            <EmptyCard cardTitle="My card title" message="My message" description="My description" />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('expect to render with cardTitle as Element', () => {
+        const wrapper = shallow(
+            <EmptyCard cardTitle={<h1>My Title</h1>} message="My message" description="My description" />
+        );
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/src/PresentationalComponents/EmptyCard/EmptyCard.test.tsx
+++ b/src/PresentationalComponents/EmptyCard/EmptyCard.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EmptyCard } from './EmptyCard';
+
+describe('EmptyCard', () => {
+    it('expect to render', () => {
+        const wrapper = shallow(<EmptyCard title="My Title" />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('expect to render with title as Element', () => {
+        const wrapper = shallow(<EmptyCard title={<h1>My Title</h1>} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/EmptyCard/EmptyCard.tsx
+++ b/src/PresentationalComponents/EmptyCard/EmptyCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card, CardBody, Bullseye, EmptyState, EmptyStateVariant, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { InfoIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Card/card';
+import titleStyles from '@patternfly/react-styles/css/components/Title/title';
+
+interface Props {
+    title: string | React.ReactElement;
+    minHeight?: number;
+}
+
+export const EmptyCard: React.FC<Props> = ({ title, minHeight }) => {
+    return (
+        <Card>
+            <div className={css(styles.cardHeader, titleStyles.title, titleStyles.modifiers.xl)}>{title}</div>
+            <CardBody style={minHeight ? { height: minHeight } : undefined}>
+                <Bullseye>
+                    <EmptyState variant={EmptyStateVariant.full}>
+                        <EmptyStateIcon icon={InfoIcon} />
+                        <Title headingLevel="h6" size="lg">
+                            Not enough data to show this card.
+                        </Title>
+                    </EmptyState>
+                </Bullseye>
+            </CardBody>
+        </Card>
+    );
+};

--- a/src/PresentationalComponents/EmptyCard/EmptyCard.tsx
+++ b/src/PresentationalComponents/EmptyCard/EmptyCard.tsx
@@ -1,26 +1,38 @@
 import React from 'react';
-import { Card, CardBody, Bullseye, EmptyState, EmptyStateVariant, EmptyStateIcon, Title } from '@patternfly/react-core';
-import { InfoIcon } from '@patternfly/react-icons';
+import {
+    Card,
+    CardBody,
+    Bullseye,
+    EmptyState,
+    EmptyStateVariant,
+    EmptyStateIcon,
+    Title,
+    EmptyStateBody
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Card/card';
 import titleStyles from '@patternfly/react-styles/css/components/Title/title';
 
 interface Props {
-    title: string | React.ReactElement;
+    cardTitle: string | React.ReactElement;
+    message: string;
+    description?: string;
     minHeight?: number;
 }
 
-export const EmptyCard: React.FC<Props> = ({ title, minHeight }) => {
+export const EmptyCard: React.FC<Props> = ({ cardTitle, message, description, minHeight }) => {
     return (
         <Card>
-            <div className={css(styles.cardHeader, titleStyles.title, titleStyles.modifiers.xl)}>{title}</div>
+            <div className={css(styles.cardHeader, titleStyles.title, titleStyles.modifiers.xl)}>{cardTitle}</div>
             <CardBody style={minHeight ? { height: minHeight } : undefined}>
                 <Bullseye>
-                    <EmptyState variant={EmptyStateVariant.full}>
-                        <EmptyStateIcon icon={InfoIcon} />
+                    <EmptyState variant={EmptyStateVariant.small}>
+                        <EmptyStateIcon icon={SearchIcon} />
                         <Title headingLevel="h6" size="lg">
-                            Not enough data to show this card.
+                            {message}
                         </Title>
+                        {description && <EmptyStateBody>{description}</EmptyStateBody>}
                     </EmptyState>
                 </Bullseye>
             </CardBody>

--- a/src/PresentationalComponents/EmptyCard/__snapshots__/EmptyCard.test.tsx.snap
+++ b/src/PresentationalComponents/EmptyCard/__snapshots__/EmptyCard.test.tsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmptyCard expect to render 1`] = `
+<Card>
+  <div
+    className="pf-c-card__header pf-c-title pf-m-xl"
+  >
+    My Title
+  </div>
+  <CardBody>
+    <Bullseye>
+      <EmptyState
+        variant="full"
+      >
+        <EmptyStateIcon
+          icon={[Function]}
+        />
+        <Title
+          headingLevel="h6"
+          size="lg"
+        >
+          Not enough data to show this card.
+        </Title>
+      </EmptyState>
+    </Bullseye>
+  </CardBody>
+</Card>
+`;
+
+exports[`EmptyCard expect to render with title as Element 1`] = `
+<Card>
+  <div
+    className="pf-c-card__header pf-c-title pf-m-xl"
+  >
+    <h1>
+      My Title
+    </h1>
+  </div>
+  <CardBody>
+    <Bullseye>
+      <EmptyState
+        variant="full"
+      >
+        <EmptyStateIcon
+          icon={[Function]}
+        />
+        <Title
+          headingLevel="h6"
+          size="lg"
+        >
+          Not enough data to show this card.
+        </Title>
+      </EmptyState>
+    </Bullseye>
+  </CardBody>
+</Card>
+`;

--- a/src/PresentationalComponents/EmptyCard/__snapshots__/EmptyCard.test.tsx.snap
+++ b/src/PresentationalComponents/EmptyCard/__snapshots__/EmptyCard.test.tsx.snap
@@ -1,33 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EmptyCard expect to render 1`] = `
-<Card>
-  <div
-    className="pf-c-card__header pf-c-title pf-m-xl"
-  >
-    My Title
-  </div>
-  <CardBody>
-    <Bullseye>
-      <EmptyState
-        variant="full"
-      >
-        <EmptyStateIcon
-          icon={[Function]}
-        />
-        <Title
-          headingLevel="h6"
-          size="lg"
-        >
-          Not enough data to show this card.
-        </Title>
-      </EmptyState>
-    </Bullseye>
-  </CardBody>
-</Card>
-`;
-
-exports[`EmptyCard expect to render with title as Element 1`] = `
+exports[`EmptyCard expect to render with cardTitle as Element 1`] = `
 <Card>
   <div
     className="pf-c-card__header pf-c-title pf-m-xl"
@@ -39,7 +12,7 @@ exports[`EmptyCard expect to render with title as Element 1`] = `
   <CardBody>
     <Bullseye>
       <EmptyState
-        variant="full"
+        variant="small"
       >
         <EmptyStateIcon
           icon={[Function]}
@@ -48,7 +21,67 @@ exports[`EmptyCard expect to render with title as Element 1`] = `
           headingLevel="h6"
           size="lg"
         >
-          Not enough data to show this card.
+          My message
+        </Title>
+        <EmptyStateBody>
+          My description
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  </CardBody>
+</Card>
+`;
+
+exports[`EmptyCard expect to render with description 1`] = `
+<Card>
+  <div
+    className="pf-c-card__header pf-c-title pf-m-xl"
+  >
+    My card title
+  </div>
+  <CardBody>
+    <Bullseye>
+      <EmptyState
+        variant="small"
+      >
+        <EmptyStateIcon
+          icon={[Function]}
+        />
+        <Title
+          headingLevel="h6"
+          size="lg"
+        >
+          My message
+        </Title>
+        <EmptyStateBody>
+          My description
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  </CardBody>
+</Card>
+`;
+
+exports[`EmptyCard expect to render without description 1`] = `
+<Card>
+  <div
+    className="pf-c-card__header pf-c-title pf-m-xl"
+  >
+    My card title
+  </div>
+  <CardBody>
+    <Bullseye>
+      <EmptyState
+        variant="small"
+      >
+        <EmptyStateIcon
+          icon={[Function]}
+        />
+        <Title
+          headingLevel="h6"
+          size="lg"
+        >
+          My message
         </Title>
       </EmptyState>
     </Bullseye>

--- a/src/PresentationalComponents/EmptyCard/index.tsx
+++ b/src/PresentationalComponents/EmptyCard/index.tsx
@@ -1,0 +1,1 @@
+export * from './EmptyCard';

--- a/src/PresentationalComponents/FancyChartDonut/FancyChartDonut.tsx
+++ b/src/PresentationalComponents/FancyChartDonut/FancyChartDonut.tsx
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import {
     ChartDonut,
     ChartDonutProps,
-    ChartLegend,
-    ChartLegendProps,
     ChartThemeColor,
     ChartThemeVariant,
     ChartTooltip
@@ -19,7 +17,6 @@ export interface FancyChartDonutData {
 interface Props {
     data: FancyChartDonutData[];
     chartProps?: ChartDonutProps;
-    chartLegendProps?: ChartLegendProps;
     tickFormat?: (label: string, value: number, data: any) => string;
     tooltipFormat?: (datum: any, active: boolean) => string;
 }
@@ -34,7 +31,7 @@ class FancyChartDonut extends Component<Props, State> {
     }
 
     public render() {
-        const { data, chartProps, chartLegendProps, tickFormat, tooltipFormat } = this.props;
+        const { data, chartProps, tickFormat, tooltipFormat } = this.props;
 
         const chartData = data.map((val) => {
             return {
@@ -50,8 +47,6 @@ class FancyChartDonut extends Component<Props, State> {
             };
         });
 
-        const colorScale = !data.some((val) => !val.color) ? data.map((val) => val.color || '') : undefined;
-
         const chartLabels = ({datum}): string => {
             return tickFormat ? tickFormat(datum.x, datum.y, datum.extraData) : `${datum.x}: ${datum.y}`;
         };
@@ -60,24 +55,26 @@ class FancyChartDonut extends Component<Props, State> {
             <React.Fragment>
                 <div className="pf-u-display-flex">
                     <div className="donut-chart-container">
-                        <ChartDonut
-                            data={ chartData }
-                            themeColor={colorScale ? undefined : ChartThemeColor.multiOrdered}
-                            themeVariant={colorScale ? undefined : ChartThemeVariant.light}
-                            colorScale={ colorScale }
-                            labels={ chartLabels }
-                            labelComponent={  <ChartTooltip text={ tooltipFormat ? tooltipFormat : undefined }/> }
-                            { ...chartProps }
-                        />
-                    </div>
-                    <ChartLegend
-                        data={ legendData }
-                        colorScale={ colorScale }
-                        themeColor={colorScale ? undefined : ChartThemeColor.multiOrdered}
-                        themeVariant={colorScale ? undefined : ChartThemeVariant.light}
-                        orientation="vertical"
-                        { ...chartLegendProps }
+                    <ChartDonut
+                        constrainToVisibleArea={true}
+                        data={ chartData }
+                        labels={ chartLabels }
+                        labelComponent={  <ChartTooltip text={ tooltipFormat ? tooltipFormat : undefined }/> }
+                        legendData={ legendData }
+                        legendOrientation="vertical"
+                        legendPosition="right"
+                        themeColor={ChartThemeColor.multiOrdered}
+                        themeVariant={ChartThemeVariant.light}
+                        padding={{
+                            bottom: 20,
+                            left: 20,
+                            right: 140, // Adjusted to accommodate legend
+                            top: 20
+                        }}
+                        width={550}
+                        { ...chartProps }
                     />
+                    </div>
                 </div>
             </React.Fragment>
         );

--- a/src/PresentationalComponents/FancyChartDonut/__snapshots__/FancyChartDonut.test.tsx.snap
+++ b/src/PresentationalComponents/FancyChartDonut/__snapshots__/FancyChartDonut.test.tsx.snap
@@ -9,14 +9,7 @@ exports[`FancyChartDonut expect to render with minimun props 1`] = `
       className="donut-chart-container"
     >
       <ChartDonut
-        colorScale={
-          Array [
-            "red",
-            "blue",
-            "yellow",
-            "green",
-          ]
-        }
+        constrainToVisibleArea={true}
         data={
           Array [
             Object {
@@ -43,35 +36,37 @@ exports[`FancyChartDonut expect to render with minimun props 1`] = `
         }
         labelComponent={<ChartTooltip />}
         labels={[Function]}
+        legendData={
+          Array [
+            Object {
+              "name": "year1: 10",
+            },
+            Object {
+              "name": "year2: 20",
+            },
+            Object {
+              "name": "year3: 30",
+            },
+            Object {
+              "name": "year4: 40",
+            },
+          ]
+        }
+        legendOrientation="vertical"
+        legendPosition="right"
+        padding={
+          Object {
+            "bottom": 20,
+            "left": 20,
+            "right": 140,
+            "top": 20,
+          }
+        }
+        themeColor="multi-ordered"
+        themeVariant="light"
+        width={550}
       />
     </div>
-    <ChartLegend
-      colorScale={
-        Array [
-          "red",
-          "blue",
-          "yellow",
-          "green",
-        ]
-      }
-      data={
-        Array [
-          Object {
-            "name": "year1: 10",
-          },
-          Object {
-            "name": "year2: 20",
-          },
-          Object {
-            "name": "year3: 30",
-          },
-          Object {
-            "name": "year4: 40",
-          },
-        ]
-      }
-      orientation="vertical"
-    />
   </div>
 </Fragment>
 `;

--- a/src/PresentationalComponents/SolidCard/SolidCard.test.tsx
+++ b/src/PresentationalComponents/SolidCard/SolidCard.test.tsx
@@ -7,4 +7,9 @@ describe('SolidCard', () => {
         const wrapper = shallow(<SolidCard title="My Title" description="My description" />);
         expect(wrapper).toMatchSnapshot();
     });
+
+    it('expect to render with setted width', () => {
+        const wrapper = shallow(<SolidCard title="My Title" description="My description" width={123} />);
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/src/PresentationalComponents/SolidCard/SolidCard.tsx
+++ b/src/PresentationalComponents/SolidCard/SolidCard.tsx
@@ -18,7 +18,7 @@ export class SolidCard extends React.Component<Props, State> {
         const { title, description, width } = this.props;
 
         return (
-            <Card className="xa-c-card-solid" style={width ? { width: width } : undefined}>
+            <Card className="xa-c-card-solid" style={width ? { width } : undefined}>
                 <CardBody>
                     <h2 className="pf-c-title pf-m-3xl">{title}</h2>
                     <p>{description}</p>

--- a/src/PresentationalComponents/SolidCard/SolidCard.tsx
+++ b/src/PresentationalComponents/SolidCard/SolidCard.tsx
@@ -20,7 +20,7 @@ export class SolidCard extends React.Component<Props, State> {
             <Card className="xa-c-card-solid">
                 <CardBody>
                     <h2 className="pf-c-title pf-m-3xl">{title}</h2>
-                    <h3 className="pf-c-title pf-m-1xl">{description}</h3>
+                    <p>{description}</p>
                 </CardBody>
             </Card>
         );

--- a/src/PresentationalComponents/SolidCard/SolidCard.tsx
+++ b/src/PresentationalComponents/SolidCard/SolidCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardBody } from '@patternfly/react-core';
 interface Props {
     title: string;
     description: string;
+    width?: number;
 }
 
 interface State {}
@@ -14,10 +15,10 @@ export class SolidCard extends React.Component<Props, State> {
     }
 
     public render() {
-        const { title, description } = this.props;
+        const { title, description, width } = this.props;
 
         return (
-            <Card className="xa-c-card-solid">
+            <Card className="xa-c-card-solid" style={width ? { width: width } : undefined}>
                 <CardBody>
                     <h2 className="pf-c-title pf-m-3xl">{title}</h2>
                     <p>{description}</p>

--- a/src/PresentationalComponents/SolidCard/__snapshots__/SolidCard.test.tsx.snap
+++ b/src/PresentationalComponents/SolidCard/__snapshots__/SolidCard.test.tsx.snap
@@ -10,11 +10,9 @@ exports[`SolidCard expect to render 1`] = `
     >
       My Title
     </h2>
-    <h3
-      className="pf-c-title pf-m-1xl"
-    >
+    <p>
       My description
-    </h3>
+    </p>
   </CardBody>
 </Card>
 `;

--- a/src/PresentationalComponents/SolidCard/__snapshots__/SolidCard.test.tsx.snap
+++ b/src/PresentationalComponents/SolidCard/__snapshots__/SolidCard.test.tsx.snap
@@ -16,3 +16,25 @@ exports[`SolidCard expect to render 1`] = `
   </CardBody>
 </Card>
 `;
+
+exports[`SolidCard expect to render with setted width 1`] = `
+<Card
+  className="xa-c-card-solid"
+  style={
+    Object {
+      "width": 123,
+    }
+  }
+>
+  <CardBody>
+    <h2
+      className="pf-c-title pf-m-3xl"
+    >
+      My Title
+    </h2>
+    <p>
+      My description
+    </p>
+  </CardBody>
+</Card>
+`;

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.test.tsx
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { JavaRuntimesCard } from './JavaRuntimesCard';
+import { ApplicationPlatformsCard } from './ApplicationPlatformsCard';
 import { ReportWorkloadSummary } from 'src/models';
 
 const BasicReportWorkloadSummary: ReportWorkloadSummary = {
@@ -25,35 +25,35 @@ const BasicReportWorkloadSummary: ReportWorkloadSummary = {
     applicationPlatforms: []
 };
 
-describe('JavaRuntimesCard', () => {
+describe('ApplicationPlatformsCard', () => {
     it('expect to render', () => {
         const reportWorkloadSummary: ReportWorkloadSummary = {
             ...BasicReportWorkloadSummary,
-            javaRuntimes: [
+            applicationPlatforms: [
                 {
-                    vendor: 'VendorA',
-                    version: '8',
+                    name: 'Application1',
+                    version: null,
                     total: 10
                 },
                 {
-                    vendor: 'VendorB',
-                    version: '11',
+                    name: 'Application2',
+                    version: null,
                     total: 20
                 },
                 {
-                    vendor: 'VendorB',
-                    version: '8',
+                    name: 'Application2',
+                    version: null,
                     total: 15
                 }
             ]
         };
 
-        const wrapper = shallow(<JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />);
+        const wrapper = shallow(<ApplicationPlatformsCard reportWorkloadSummary={reportWorkloadSummary} />);
         expect(wrapper).toMatchSnapshot();
     });
 
     it('expect to render empty card when undefined reportWorkloadSummary', () => {
-        const wrapper = shallow(<JavaRuntimesCard reportWorkloadSummary={null} />);
+        const wrapper = shallow(<ApplicationPlatformsCard reportWorkloadSummary={null} />);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -63,7 +63,7 @@ describe('JavaRuntimesCard', () => {
             javaRuntimes: []
         };
 
-        const wrapper = shallow(<JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />);
+        const wrapper = shallow(<ApplicationPlatformsCard reportWorkloadSummary={reportWorkloadSummary} />);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
@@ -45,15 +45,7 @@ export const ApplicationPlatformsCard: React.FC<Props> = ({ reportWorkloadSummar
 
     const chartProps = {
         title: formatNumber(total, 0),
-        subTitle: 'Total',
-        height: 250,
-        width: 250
-    };
-    const chartLegendProps = {
-        height: 250,
-        width: 210,
-        responsive: false,
-        y: 70
+        subTitle: 'Total'
     };
 
     const chartData: FancyChartDonutData[] = orderedApplicationPlatforms.map((element, index: number) => ({
@@ -76,7 +68,6 @@ export const ApplicationPlatformsCard: React.FC<Props> = ({ reportWorkloadSummar
                         <FancyChartDonut
                             data={chartData}
                             chartProps={chartProps}
-                            chartLegendProps={chartLegendProps}
                             tickFormat={tickFormat}
                             tooltipFormat={tooltipFormat}
                         />

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Bullseye, Grid, GridItem } from '@patternfly/react-core';
+import ReportCard from '../../ReportCard';
+import { ReportWorkloadSummary, ApplicationPlatformModel } from '../../../models';
+import FancyChartDonut from '../../FancyChartDonut';
+import { FancyChartDonutData } from '../../FancyChartDonut/FancyChartDonut';
+import { formatNumber, formatPercentage } from '../../../Utilities/formatValue';
+import { EmptyCard } from '../../EmptyCard';
+import { SolidCard } from '../../SolidCard';
+
+interface Props {
+    reportWorkloadSummary: ReportWorkloadSummary | null;
+}
+
+export const ApplicationPlatformsCard: React.FC<Props> = ({ reportWorkloadSummary }) => {
+    const title = 'Application platforms information';
+
+    if (
+        !reportWorkloadSummary ||
+        !reportWorkloadSummary.applicationPlatforms ||
+        reportWorkloadSummary.applicationPlatforms.length === 0
+    ) {
+        return (
+            <EmptyCard
+                cardTitle={title}
+                message="No app platforms found"
+                description="No app platforms have been discovered."
+            />
+        );
+    }
+
+    const applicationPlatforms = reportWorkloadSummary.applicationPlatforms;
+
+    const orderedApplicationPlatforms = applicationPlatforms.sort((a: ApplicationPlatformModel, b: ApplicationPlatformModel) => {
+        return a.name.localeCompare(b.name);
+    });
+
+    const totalWithoutEAP = applicationPlatforms.filter(e => e.name !== 'JBoss EAP').map(e => e.total).reduce((a: number, b: number) => a + b);
+
+    //
+    const pieValues = orderedApplicationPlatforms.map(element => element.total);
+
+    const total = pieValues.reduce((a: number, b: number) => a + b, 0);
+    const percentages = pieValues.map((val: number) => val / total);
+
+    const chartProps = {
+        title: formatNumber(total, 0),
+        subTitle: 'Total',
+        height: 250,
+        width: 250
+    };
+    const chartLegendProps = {
+        height: 250,
+        width: 210,
+        responsive: false,
+        y: 70
+    };
+
+    const chartData: FancyChartDonutData[] = orderedApplicationPlatforms.map((element, index: number) => ({
+        label: `${element.name}`,
+        value: percentages[index],
+        extraData: pieValues[index]
+    }));
+
+    const tickFormat = (label: string, value: number, data: any) => {
+        return `${label}: ${data}`;
+    };
+    const tooltipFormat = ({ datum }) =>
+        `${datum.x}: ${formatPercentage(datum.y, 2)} \n Total: ${formatNumber(datum.extraData, 0)}`;
+
+    return (
+        <ReportCard title={title} skipBullseye={true}>
+            <Grid xl={6}>
+                <GridItem>
+                    <Bullseye>
+                        <FancyChartDonut
+                            data={chartData}
+                            chartProps={chartProps}
+                            chartLegendProps={chartLegendProps}
+                            tickFormat={tickFormat}
+                            tooltipFormat={tooltipFormat}
+                        />
+                    </Bullseye>
+                </GridItem>
+                <GridItem>
+                    <Bullseye>
+                        <SolidCard
+                            title={`${totalWithoutEAP} JBoss EAP`}
+                            description="App platforms that can be replatformed with JBoss EAP"
+                            width={510}
+                        />
+                    </Bullseye>
+                </GridItem>
+            </Grid>
+        </ReportCard>
+    );
+};

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/__snapshots__/ApplicationPlatformsCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/__snapshots__/ApplicationPlatformsCard.test.tsx.snap
@@ -11,20 +11,10 @@ exports[`ApplicationPlatformsCard expect to render 1`] = `
     <GridItem>
       <Bullseye>
         <FancyChartDonut
-          chartLegendProps={
-            Object {
-              "height": 250,
-              "responsive": false,
-              "width": 210,
-              "y": 70,
-            }
-          }
           chartProps={
             Object {
-              "height": 250,
               "subTitle": "Total",
               "title": "45",
-              "width": 250,
             }
           }
           data={

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/__snapshots__/ApplicationPlatformsCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/__snapshots__/ApplicationPlatformsCard.test.tsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationPlatformsCard expect to render 1`] = `
+<ReportCard
+  skipBullseye={true}
+  title="Application platforms information"
+>
+  <Grid
+    xl={6}
+  >
+    <GridItem>
+      <Bullseye>
+        <FancyChartDonut
+          chartLegendProps={
+            Object {
+              "height": 250,
+              "responsive": false,
+              "width": 210,
+              "y": 70,
+            }
+          }
+          chartProps={
+            Object {
+              "height": 250,
+              "subTitle": "Total",
+              "title": "45",
+              "width": 250,
+            }
+          }
+          data={
+            Array [
+              Object {
+                "extraData": 10,
+                "label": "Application1",
+                "value": 0.2222222222222222,
+              },
+              Object {
+                "extraData": 20,
+                "label": "Application2",
+                "value": 0.4444444444444444,
+              },
+              Object {
+                "extraData": 15,
+                "label": "Application2",
+                "value": 0.3333333333333333,
+              },
+            ]
+          }
+          tickFormat={[Function]}
+          tooltipFormat={[Function]}
+        />
+      </Bullseye>
+    </GridItem>
+    <GridItem>
+      <Bullseye>
+        <SolidCard
+          description="App platforms that can be replatformed with JBoss EAP"
+          title="45 JBoss EAP"
+          width={510}
+        />
+      </Bullseye>
+    </GridItem>
+  </Grid>
+</ReportCard>
+`;
+
+exports[`ApplicationPlatformsCard expect to render empty card when no java runtimes 1`] = `
+<Component
+  cardTitle="Application platforms information"
+  description="No app platforms have been discovered."
+  message="No app platforms found"
+/>
+`;
+
+exports[`ApplicationPlatformsCard expect to render empty card when undefined reportWorkloadSummary 1`] = `
+<Component
+  cardTitle="Application platforms information"
+  description="No app platforms have been discovered."
+  message="No app platforms found"
+/>
+`;

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/index.tsx
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/index.tsx
@@ -1,0 +1,1 @@
+export * from './ApplicationPlatformsCard';

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.test.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { JavaRuntimesCard } from './JavaRuntimesCard';
+import { ReportWorkloadSummary } from 'src/models';
+
+const BasicReportWorkloadSummary: ReportWorkloadSummary = {
+    complexityModel: {
+        easy: 1,
+        hard: 2,
+        medium: 3,
+        unknown: 4,
+        unsupported: 5
+    },
+    recommendedTargetsIMSModel: {
+        ocp: 10,
+        osp: 20,
+        rhel: 30,
+        rhv: 40,
+        total: 100
+    },
+    scanRunModels: [],
+    summaryModels: [],
+    workloadsDetectedOSTypeModels: [],
+    javaRuntimes: []
+};
+
+describe('JavaRuntimesCard', () => {
+    it('expect to render', () => {
+        const reportWorkloadSummary: ReportWorkloadSummary = {
+            ...BasicReportWorkloadSummary,
+            javaRuntimes: [
+                {
+                    vendor: 'VendorA',
+                    version: '8',
+                    total: 10
+                },
+                {
+                    vendor: 'VendorB',
+                    version: '11',
+                    total: 20
+                },
+                {
+                    vendor: 'VendorB',
+                    version: '8',
+                    total: 15
+                }
+            ]
+        };
+
+        const wrapper = shallow(<JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('expect to render empty card when undefined reportWorkloadSummary', () => {
+        const wrapper = shallow(<JavaRuntimesCard reportWorkloadSummary={null} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('expect to render empty card when no java runtimes', () => {
+        const reportWorkloadSummary: ReportWorkloadSummary = {
+            ...BasicReportWorkloadSummary,
+            javaRuntimes: []
+        };
+
+        const wrapper = shallow(<JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
@@ -46,15 +46,7 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
 
     const chartProps = {
         title: formatNumber(total, 0),
-        subTitle: 'Total',
-        height: 250,
-        width: 250
-    };
-    const chartLegendProps = {
-        height: 250,
-        width: 210,
-        responsive: false,
-        y: 70
+        subTitle: 'Total'
     };
 
     const chartData: FancyChartDonutData[] = orderedJavaRuntimes.map((element, index: number) => ({
@@ -77,7 +69,6 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
                         <FancyChartDonut
                             data={chartData}
                             chartProps={chartProps}
-                            chartLegendProps={chartLegendProps}
                             tickFormat={tickFormat}
                             tooltipFormat={tooltipFormat}
                         />

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
@@ -71,7 +71,7 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
 
     return (
         <ReportCard title={title} skipBullseye={true}>
-            <Grid sm={12} lg={6} xl={6}>
+            <Grid xl={6}>
                 <GridItem>
                     <Bullseye>
                         <FancyChartDonut
@@ -88,6 +88,7 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
                         <SolidCard
                             title={`${total} OpenJDK`}
                             description="Oracle JDKs that can be replaced with OpenJDK"
+                            width={510}
                         />
                     </Bullseye>
                 </GridItem>

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Stack, StackItem, Divider, Bullseye } from '@patternfly/react-core';
-import { BullseyeIcon } from '@patternfly/react-icons';
+import { Bullseye, Grid, GridItem } from '@patternfly/react-core';
 import ReportCard from '../../ReportCard';
-import { ReportWorkloadSummary, JavaRuntimeModel } from 'src/models';
+import { ReportWorkloadSummary, JavaRuntimeModel } from '../../../models';
 import FancyChartDonut from '../../FancyChartDonut';
 import { FancyChartDonutData } from '../../FancyChartDonut/FancyChartDonut';
 import { formatNumber, formatPercentage } from '../../../Utilities/formatValue';
 import { EmptyCard } from '../../EmptyCard';
+import { SolidCard } from '../../../PresentationalComponents/SolidCard';
 
 interface Props {
     reportWorkloadSummary: ReportWorkloadSummary | null;
@@ -15,14 +15,21 @@ interface Props {
 export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => {
     const title = 'Oracle Java runtimes information';
 
-    if (!reportWorkloadSummary) {
-        return <EmptyCard title={title} />;
+    if (
+        !reportWorkloadSummary ||
+        !reportWorkloadSummary.javaRuntimes ||
+        reportWorkloadSummary.javaRuntimes.length === 0
+    ) {
+        return (
+            <EmptyCard
+                cardTitle={title}
+                message="No instances found"
+                description="No instances of Oracle JDKs have been discovered."
+            />
+        );
     }
 
     const javaRuntimes = reportWorkloadSummary.javaRuntimes;
-    if (!javaRuntimes || javaRuntimes.length === 0) {
-        return <EmptyCard title={title} />;
-    }
 
     const orderedJavaRuntimes = javaRuntimes.sort((a: JavaRuntimeModel, b: JavaRuntimeModel) => {
         if (a.vendor === b.vendor) {
@@ -40,18 +47,18 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
     const chartProps = {
         title: formatNumber(total, 0),
         subTitle: 'Total',
-        height: 270,
-        width: 300
+        height: 250,
+        width: 250
     };
     const chartLegendProps = {
-        height: 200,
+        height: 250,
         width: 210,
         responsive: false,
-        y: 60
+        y: 70
     };
 
     const chartData: FancyChartDonutData[] = orderedJavaRuntimes.map((element, index: number) => ({
-        label: element.vendor + ' ' + element.version,
+        label: `${element.vendor} JDK ${element.version}`,
         value: percentages[index],
         extraData: pieValues[index]
     }));
@@ -60,24 +67,12 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
         return `${label}: ${data}`;
     };
     const tooltipFormat = ({ datum }) =>
-        `${datum.x}: ${formatPercentage(datum.y, 2)} \n Runtimes: ${formatNumber(datum.extraData, 0)}`;
+        `${datum.x}: ${formatPercentage(datum.y, 2)} \n Total: ${formatNumber(datum.extraData, 0)}`;
 
     return (
         <ReportCard title={title} skipBullseye={true}>
-            <Stack>
-                <StackItem>
-                    <div className="pf-c-content">
-                        <h5>
-                            <i>
-                                <BullseyeIcon />
-                            </i>{' '}
-                            {total} Oracle JDKs can be replaced with OpenJDK
-                        </h5>
-                        <br />
-                        <Divider component="div" />
-                    </div>
-                </StackItem>
-                <StackItem isFilled>
+            <Grid sm={12} lg={6} xl={6}>
+                <GridItem>
                     <Bullseye>
                         <FancyChartDonut
                             data={chartData}
@@ -87,8 +82,16 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
                             tooltipFormat={tooltipFormat}
                         />
                     </Bullseye>
-                </StackItem>
-            </Stack>
+                </GridItem>
+                <GridItem>
+                    <Bullseye>
+                        <SolidCard
+                            title={`${total} OpenJDK`}
+                            description="Oracle JDKs that can be replaced with OpenJDK"
+                        />
+                    </Bullseye>
+                </GridItem>
+            </Grid>
         </ReportCard>
     );
 };

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Stack, StackItem, Divider, Bullseye } from '@patternfly/react-core';
+import { BullseyeIcon } from '@patternfly/react-icons';
+import ReportCard from '../../ReportCard';
+import { ReportWorkloadSummary, JavaRuntimeModel } from 'src/models';
+import FancyChartDonut from '../../FancyChartDonut';
+import { FancyChartDonutData } from '../../FancyChartDonut/FancyChartDonut';
+import { formatNumber, formatPercentage } from '../../../Utilities/formatValue';
+import { EmptyCard } from '../../EmptyCard';
+
+interface Props {
+    reportWorkloadSummary: ReportWorkloadSummary | null;
+}
+
+export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => {
+    const title = 'Oracle Java runtimes information';
+
+    if (!reportWorkloadSummary) {
+        return <EmptyCard title={title} />;
+    }
+
+    const javaRuntimes = reportWorkloadSummary.javaRuntimes;
+    if (!javaRuntimes || javaRuntimes.length === 0) {
+        return <EmptyCard title={title} />;
+    }
+
+    const orderedJavaRuntimes = javaRuntimes.sort((a: JavaRuntimeModel, b: JavaRuntimeModel) => {
+        if (a.vendor === b.vendor) {
+            return Number(a.version) - Number(b.version);
+        }
+        return a.vendor.localeCompare(b.vendor);
+    });
+
+    //
+    const pieValues = orderedJavaRuntimes.map(element => element.total);
+
+    const total = pieValues.reduce((a: number, b: number) => a + b, 0);
+    const percentages = pieValues.map((val: number) => val / total);
+
+    const chartProps = {
+        title: formatNumber(total, 0),
+        subTitle: 'Total',
+        height: 270,
+        width: 300
+    };
+    const chartLegendProps = {
+        height: 200,
+        width: 210,
+        responsive: false,
+        y: 60
+    };
+
+    const chartData: FancyChartDonutData[] = orderedJavaRuntimes.map((element, index: number) => ({
+        label: element.vendor + ' ' + element.version,
+        value: percentages[index],
+        extraData: pieValues[index]
+    }));
+
+    const tickFormat = (label: string, value: number, data: any) => {
+        return `${label}: ${data}`;
+    };
+    const tooltipFormat = ({ datum }) =>
+        `${datum.x}: ${formatPercentage(datum.y, 2)} \n Runtimes: ${formatNumber(datum.extraData, 0)}`;
+
+    return (
+        <ReportCard title={title} skipBullseye={true}>
+            <Stack>
+                <StackItem>
+                    <div className="pf-c-content">
+                        <h5>
+                            <i>
+                                <BullseyeIcon />
+                            </i>{' '}
+                            {total} Oracle JDKs can be replaced with OpenJDK
+                        </h5>
+                        <br />
+                        <Divider component="div" />
+                    </div>
+                </StackItem>
+                <StackItem isFilled>
+                    <Bullseye>
+                        <FancyChartDonut
+                            data={chartData}
+                            chartProps={chartProps}
+                            chartLegendProps={chartLegendProps}
+                            tickFormat={tickFormat}
+                            tooltipFormat={tooltipFormat}
+                        />
+                    </Bullseye>
+                </StackItem>
+            </Stack>
+        </ReportCard>
+    );
+};

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
@@ -5,66 +5,45 @@ exports[`JavaRuntimesCard expect to render 1`] = `
   skipBullseye={true}
   title="Oracle Java runtimes information"
 >
-  <Stack>
-    <StackItem>
-      <div
-        className="pf-c-content"
-      >
-        <h5>
-          <i>
-            <BullseyeIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-              title={null}
-            />
-          </i>
-           
-          45
-           Oracle JDKs can be replaced with OpenJDK
-        </h5>
-        <br />
-        <Divider
-          component="div"
-        />
-      </div>
-    </StackItem>
-    <StackItem
-      isFilled={true}
-    >
+  <Grid
+    lg={6}
+    sm={12}
+    xl={6}
+  >
+    <GridItem>
       <Bullseye>
         <FancyChartDonut
           chartLegendProps={
             Object {
-              "height": 200,
+              "height": 250,
               "responsive": false,
               "width": 210,
-              "y": 60,
+              "y": 70,
             }
           }
           chartProps={
             Object {
-              "height": 270,
+              "height": 250,
               "subTitle": "Total",
               "title": "45",
-              "width": 300,
+              "width": 250,
             }
           }
           data={
             Array [
               Object {
                 "extraData": 10,
-                "label": "VendorA 8",
+                "label": "VendorA JDK 8",
                 "value": 0.2222222222222222,
               },
               Object {
                 "extraData": 15,
-                "label": "VendorB 8",
+                "label": "VendorB JDK 8",
                 "value": 0.3333333333333333,
               },
               Object {
                 "extraData": 20,
-                "label": "VendorB 11",
+                "label": "VendorB JDK 11",
                 "value": 0.4444444444444444,
               },
             ]
@@ -73,19 +52,31 @@ exports[`JavaRuntimesCard expect to render 1`] = `
           tooltipFormat={[Function]}
         />
       </Bullseye>
-    </StackItem>
-  </Stack>
+    </GridItem>
+    <GridItem>
+      <Bullseye>
+        <SolidCard
+          description="Oracle JDKs that can be replaced with OpenJDK"
+          title="45 OpenJDK"
+        />
+      </Bullseye>
+    </GridItem>
+  </Grid>
 </ReportCard>
 `;
 
 exports[`JavaRuntimesCard expect to render empty card when no java runtimes 1`] = `
 <Component
-  title="Oracle Java runtimes information"
+  cardTitle="Oracle Java runtimes information"
+  description="No instances of Oracle JDKs have been discovered."
+  message="No instances found"
 />
 `;
 
 exports[`JavaRuntimesCard expect to render empty card when undefined reportWorkloadSummary 1`] = `
 <Component
-  title="Oracle Java runtimes information"
+  cardTitle="Oracle Java runtimes information"
+  description="No instances of Oracle JDKs have been discovered."
+  message="No instances found"
 />
 `;

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JavaRuntimesCard expect to render 1`] = `
+<ReportCard
+  skipBullseye={true}
+  title="Oracle Java runtimes information"
+>
+  <Stack>
+    <StackItem>
+      <div
+        className="pf-c-content"
+      >
+        <h5>
+          <i>
+            <BullseyeIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+              title={null}
+            />
+          </i>
+           
+          45
+           Oracle JDKs can be replaced with OpenJDK
+        </h5>
+        <br />
+        <Divider
+          component="div"
+        />
+      </div>
+    </StackItem>
+    <StackItem
+      isFilled={true}
+    >
+      <Bullseye>
+        <FancyChartDonut
+          chartLegendProps={
+            Object {
+              "height": 200,
+              "responsive": false,
+              "width": 210,
+              "y": 60,
+            }
+          }
+          chartProps={
+            Object {
+              "height": 270,
+              "subTitle": "Total",
+              "title": "45",
+              "width": 300,
+            }
+          }
+          data={
+            Array [
+              Object {
+                "extraData": 10,
+                "label": "VendorA 8",
+                "value": 0.2222222222222222,
+              },
+              Object {
+                "extraData": 15,
+                "label": "VendorB 8",
+                "value": 0.3333333333333333,
+              },
+              Object {
+                "extraData": 20,
+                "label": "VendorB 11",
+                "value": 0.4444444444444444,
+              },
+            ]
+          }
+          tickFormat={[Function]}
+          tooltipFormat={[Function]}
+        />
+      </Bullseye>
+    </StackItem>
+  </Stack>
+</ReportCard>
+`;
+
+exports[`JavaRuntimesCard expect to render empty card when no java runtimes 1`] = `
+<Component
+  title="Oracle Java runtimes information"
+/>
+`;
+
+exports[`JavaRuntimesCard expect to render empty card when undefined reportWorkloadSummary 1`] = `
+<Component
+  title="Oracle Java runtimes information"
+/>
+`;

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
@@ -6,8 +6,6 @@ exports[`JavaRuntimesCard expect to render 1`] = `
   title="Oracle Java runtimes information"
 >
   <Grid
-    lg={6}
-    sm={12}
     xl={6}
   >
     <GridItem>
@@ -58,6 +56,7 @@ exports[`JavaRuntimesCard expect to render 1`] = `
         <SolidCard
           description="Oracle JDKs that can be replaced with OpenJDK"
           title="45 OpenJDK"
+          width={510}
         />
       </Bullseye>
     </GridItem>

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
@@ -11,20 +11,10 @@ exports[`JavaRuntimesCard expect to render 1`] = `
     <GridItem>
       <Bullseye>
         <FancyChartDonut
-          chartLegendProps={
-            Object {
-              "height": 250,
-              "responsive": false,
-              "width": 210,
-              "y": 70,
-            }
-          }
           chartProps={
             Object {
-              "height": 250,
               "subTitle": "Total",
               "title": "45",
-              "width": 250,
             }
           }
           data={

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/index.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/index.tsx
@@ -1,0 +1,1 @@
+export * from './JavaRuntimesCard';

--- a/src/models/Report.tsx
+++ b/src/models/Report.tsx
@@ -20,6 +20,7 @@ export interface ReportWorkloadSummary {
     workloadsDetectedOSTypeModels: WorkloadDetectedOSTypeModel[];
     scanRunModels: ScanRunModel[];
     javaRuntimes: JavaRuntimeModel[];
+    applicationPlatforms: ApplicationPlatformModel[];
 }
 
 export interface Summary {
@@ -62,6 +63,12 @@ export interface ScanRunModel {
 export interface JavaRuntimeModel {
     vendor: string;
     version: string;
+    total: number;
+}
+
+export interface ApplicationPlatformModel {
+    name: string;
+    version: string | null;
     total: number;
 }
 

--- a/src/models/Report.tsx
+++ b/src/models/Report.tsx
@@ -19,6 +19,7 @@ export interface ReportWorkloadSummary {
     recommendedTargetsIMSModel: RecommendedTargetsIMSModel;
     workloadsDetectedOSTypeModels: WorkloadDetectedOSTypeModel[];
     scanRunModels: ScanRunModel[];
+    javaRuntimes: JavaRuntimeModel[];
 }
 
 export interface Summary {
@@ -56,6 +57,12 @@ export interface ScanRunModel {
     target: string;
     smartStateEnabled: boolean;
     date: number;
+}
+
+export interface JavaRuntimeModel {
+    vendor: string;
+    version: string;
+    total: number;
 }
 
 export interface WorkloadModel {

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -273,13 +273,13 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
         const chartProps = {
             title: formatValue(total, 'usd', { fractionDigits: 0 }),
             height: 300,
-            width: 300
-        };
-        const chartLegendProps = {
-            height: 300,
-            width: 210,
-            responsive: false,
-            y: 60
+            width: 600,
+            padding: {
+                bottom: 20,
+                left: 20,
+                right: 200, // Adjusted to accommodate legend
+                top: 20
+            }
         };
 
         const chartData: FancyChartDonutData[] = [
@@ -299,7 +299,6 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                 <FancyChartDonut
                     data={ chartData }
                     chartProps={ chartProps }
-                    chartLegendProps={ chartLegendProps }
                     tickFormat={ tickFormat }
                     tooltipFormat={ tooltipFormat }
                 />

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.test.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.test.tsx
@@ -52,7 +52,8 @@ describe('WorkloadMigrationSummary', () => {
                 recommendedTargetsIMSModel: { total: 126, rhv: 122, rhel: 7, osp: 121, ocp: 111 },
                 workloadsDetectedOSTypeModels: [{ osName: 'ServerNT', total: 1 }, { osName: 'Linux', total: 4 }],
                 scanRunModels: [{ target: 'VMware', date: 1580774400000, smartStateEnabled: true }],
-                javaRuntimes: []
+                javaRuntimes: [],
+                applicationPlatforms: []
             },
             reportWorkloadSummaryFetchStatus: { error: null, status: 'complete' },
             fetchReportWorkloadSummary: (reportId: number) => ({

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.test.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.test.tsx
@@ -51,7 +51,8 @@ describe('WorkloadMigrationSummary', () => {
                 complexityModel: { easy: 111, medium: 11, hard: 0, unknown: 0, unsupported: 4 },
                 recommendedTargetsIMSModel: { total: 126, rhv: 122, rhel: 7, osp: 121, ocp: 111 },
                 workloadsDetectedOSTypeModels: [{ osName: 'ServerNT', total: 1 }, { osName: 'Linux', total: 4 }],
-                scanRunModels: [{ target: 'VMware', date: 1580774400000, smartStateEnabled: true }]
+                scanRunModels: [{ target: 'VMware', date: 1580774400000, smartStateEnabled: true }],
+                javaRuntimes: []
             },
             reportWorkloadSummaryFetchStatus: { error: null, status: 'complete' },
             fetchReportWorkloadSummary: (reportId: number) => ({

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -30,6 +30,7 @@ import { ObjectFetchStatus } from '../../../models/state';
 import { ReportWorkloadSummary } from '../../../models';
 import { JavaRuntimesCard } from '../../../PresentationalComponents/WorkladSummary/JavaRuntimesCard';
 import { EmptyCard } from '../../../PresentationalComponents/EmptyCard';
+import { ApplicationPlatformsCard } from '../../../PresentationalComponents/WorkladSummary/ApplicationPlatformsCard';
 
 interface StateToProps {
     reportWorkloadSummary: ReportWorkloadSummary | null;
@@ -244,6 +245,11 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
         return <JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />;
     }
 
+    public renderApplicationPlatforms = () => {
+        const { reportWorkloadSummary } = this.props;
+        return <ApplicationPlatformsCard reportWorkloadSummary={reportWorkloadSummary} />;
+    }
+    
     public renderFlagsTable = () => {
         const { reportId } = this.props;
 
@@ -299,6 +305,9 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
                     </StackItem>
                     <StackItem isFilled={ false }>
                         { this.renderJavaRuntimes() }
+                    </StackItem>
+                    <StackItem isFilled={ false }>
+                        { this.renderApplicationPlatforms() }
                     </StackItem>
                     <StackItem isFilled={ false }>
                         { this.renderWorkloadsDetectedTable() }

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -128,15 +128,7 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
 
         const chartProps = {
             title: formatNumber(total, 0),
-            subTitle: 'Total VMs',
-            height: 250,
-            width: 250
-        };
-        const chartLegendProps = {
-            height: 300,
-            width: 210,
-            responsive: false,
-            y: 60
+            subTitle: 'Total VMs'
         };
 
         const chartData: FancyChartDonutData[] = [
@@ -171,7 +163,6 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
                 <FancyChartDonut
                     data={ chartData }
                     chartProps={ chartProps }
-                    chartLegendProps={ chartLegendProps }
                     tickFormat={ tickFormat }
                     tooltipFormat={ tooltipFormat }
                 />

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -14,9 +14,7 @@ import {
     TitleLevel,
     Stack,
     StackItem,
-    Tooltip,
-    Grid,
-    GridItem
+    Tooltip
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
 import ReportCard from '../../../PresentationalComponents/ReportCard';
@@ -74,8 +72,8 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
         });
     };
 
-    public renderErrorCard = (title: string | React.ReactElement) => {
-        return <EmptyCard title={title} />;
+    public renderErrorCard = (cardTitle: string | React.ReactElement) => {
+        return <EmptyCard cardTitle={cardTitle} message="Not enought data to show this card"/>;
     };
 
     public renderSummary = () => {
@@ -241,19 +239,9 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
         );
     };
 
-    public renderOSInformation = () => {
-        const title = "OS information";
-        return <EmptyCard title={title} minHeight={311} />;
-    };
-
     public renderJavaRuntimes = () => {
         const { reportWorkloadSummary } = this.props;
         return <JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />;
-    }
-
-    public renderApplicationPlatforms = () => {
-        const title = "Application platforms information";
-        return <EmptyCard title={title} minHeight={311} />;
     }
 
     public renderFlagsTable = () => {
@@ -301,20 +289,16 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
                         { this.renderSummary() }
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        { this.renderMigrationComplexity() }
+                        { this.renderTargetRecommendation() }
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        { this.renderTargetRecommendation() }
+                        { this.renderMigrationComplexity() }
                     </StackItem>
                     <StackItem isFilled={ false }>
                         { this.renderFlagsTable() }
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        <Grid gutter="sm" lg={4}>
-                            <GridItem>{ this.renderOSInformation() }</GridItem>
-                            <GridItem>{ this.renderJavaRuntimes() }</GridItem>
-                            <GridItem>{ this.renderApplicationPlatforms() }</GridItem>
-                        </Grid>
+                        { this.renderJavaRuntimes() }
                     </StackItem>
                     <StackItem isFilled={ false }>
                         { this.renderWorkloadsDetectedTable() }

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -3,8 +3,6 @@ import {
     Skeleton,
     SkeletonTable
 } from '@redhat-cloud-services/frontend-components';
-import { ObjectFetchStatus } from '../../../models/state';
-import { ReportWorkloadSummary } from '../../../models';
 import {
     Bullseye,
     EmptyState,
@@ -16,7 +14,9 @@ import {
     TitleLevel,
     Stack,
     StackItem,
-    Tooltip
+    Tooltip,
+    Grid,
+    GridItem
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, HelpIcon } from '@patternfly/react-icons';
 import ReportCard from '../../../PresentationalComponents/ReportCard';
@@ -28,6 +28,10 @@ import ScansRunTable from '../../../PresentationalComponents/Reports/ScansRunTab
 import WorkloadsDetectedTable from '../../../SmartComponents/Reports/WorkloadsDetectedTable';
 import FlagsTable from '../../../SmartComponents/Reports/FlagsTable';
 import { SolidCard } from '../../../PresentationalComponents/SolidCard';
+import { ObjectFetchStatus } from '../../../models/state';
+import { ReportWorkloadSummary } from '../../../models';
+import { JavaRuntimesCard } from '../../../PresentationalComponents/WorkladSummary/JavaRuntimesCard';
+import { EmptyCard } from '../../../PresentationalComponents/EmptyCard';
 
 interface StateToProps {
     reportWorkloadSummary: ReportWorkloadSummary | null;
@@ -70,12 +74,8 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
         });
     };
 
-    public renderErrorCard = (title: string) => {
-        return (
-            <ReportCard title={title}>
-                There is no enough data to render this card.
-            </ReportCard>
-        );
+    public renderErrorCard = (title: string | React.ReactElement) => {
+        return <EmptyCard title={title} />;
     };
 
     public renderSummary = () => {
@@ -241,63 +241,20 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
         );
     };
 
-    public renderWorkloadsDetected = () => {
-        const { reportWorkloadSummary } = this.props;
-        const title="Workloads detected (OS Types)";
-
-        if (!reportWorkloadSummary) {
-            return this.renderErrorCard(title);
-        }
-
-        // TODO this validation was created when Models were not complete in the backend
-        // It should be safe to remove this
-        const workloadsDetectedOSTypeModels = reportWorkloadSummary.workloadsDetectedOSTypeModels;
-        if (!workloadsDetectedOSTypeModels) {
-            return this.renderErrorCard(title);
-        }
-
-        //
-        const pieValues = workloadsDetectedOSTypeModels.map(element => element.total);
-
-        const total = pieValues.reduce(sumReducer, 0);
-        const percentages = pieValues.map((val: number) => val / total);
-
-        const chartProps = {
-            title: formatNumber(total, 0),
-            subTitle: 'Total workloads',
-            height: 300,
-            width: 300
-        };
-        const chartLegendProps = {
-            height: 300,
-            width: 210,
-            responsive: false,
-            y: 60
-        };
-
-        const chartData: FancyChartDonutData[] = workloadsDetectedOSTypeModels.map((element, index: number) => ({
-            label: element.osName,
-            value: percentages[index],
-            extraData: pieValues[index]
-        }));
-
-        const tickFormat = (label: string, value: number) => `${label}: ${formatPercentage(value, 2)}`;
-        const tooltipFormat = ({datum}) => `${datum.x}: ${formatPercentage(datum.y, 2)} \n Workloads: ${formatNumber(datum.extraData, 0)}`;
-
-        return (
-            <ReportCard
-                title={title}
-            >
-                <FancyChartDonut
-                    data={ chartData }
-                    chartProps={ chartProps }
-                    chartLegendProps={ chartLegendProps }
-                    tickFormat={ tickFormat }
-                    tooltipFormat={ tooltipFormat }
-                />
-            </ReportCard>
-        );
+    public renderOSInformation = () => {
+        const title = "OS information";
+        return <EmptyCard title={title} minHeight={311} />;
     };
+
+    public renderJavaRuntimes = () => {
+        const { reportWorkloadSummary } = this.props;
+        return <JavaRuntimesCard reportWorkloadSummary={reportWorkloadSummary} />;
+    }
+
+    public renderApplicationPlatforms = () => {
+        const title = "Application platforms information";
+        return <EmptyCard title={title} minHeight={311} />;
+    }
 
     public renderFlagsTable = () => {
         const { reportId } = this.props;
@@ -350,13 +307,17 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
                         { this.renderTargetRecommendation() }
                     </StackItem>
                     <StackItem isFilled={ false }>
-                        { this.renderWorkloadsDetectedTable() }
-                    </StackItem>
-                    <StackItem isFilled={ false }>
-                        { this.renderWorkloadsDetected() }
-                    </StackItem>
-                    <StackItem isFilled={ false }>
                         { this.renderFlagsTable() }
+                    </StackItem>
+                    <StackItem isFilled={ false }>
+                        <Grid gutter="sm" lg={4}>
+                            <GridItem>{ this.renderOSInformation() }</GridItem>
+                            <GridItem>{ this.renderJavaRuntimes() }</GridItem>
+                            <GridItem>{ this.renderApplicationPlatforms() }</GridItem>
+                        </Grid>
+                    </StackItem>
+                    <StackItem isFilled={ false }>
+                        { this.renderWorkloadsDetectedTable() }
                     </StackItem>
                     <StackItem isFilled={ false }>
                         { this.renderScansRun() }

--- a/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
+++ b/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
@@ -197,9 +197,9 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
     >
       <ReportCard
         skipBullseye={true}
-        title="Workloads detected"
+        title="Flags (factors that could increase migration complexity)"
       >
-        <Connect(WorkloadsDetectedTable)
+        <Connect(FlagsTable)
           reportId={1}
         />
       </ReportCard>
@@ -207,53 +207,83 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
     <StackItem
       isFilled={false}
     >
-      <ReportCard
-        title="Workloads detected (OS Types)"
+      <Grid
+        gutter="sm"
+        lg={4}
       >
-        <FancyChartDonut
-          chartLegendProps={
-            Object {
-              "height": 300,
-              "responsive": false,
-              "width": 210,
-              "y": 60,
-            }
-          }
-          chartProps={
-            Object {
-              "height": 300,
-              "subTitle": "Total workloads",
-              "title": "5",
-              "width": 300,
-            }
-          }
-          data={
-            Array [
+        <GridItem>
+          <Component
+            minHeight={311}
+            title="OS information"
+          />
+        </GridItem>
+        <GridItem>
+          <Component
+            reportWorkloadSummary={
               Object {
-                "extraData": 1,
-                "label": "ServerNT",
-                "value": 0.2,
-              },
-              Object {
-                "extraData": 4,
-                "label": "Linux",
-                "value": 0.8,
-              },
-            ]
-          }
-          tickFormat={[Function]}
-          tooltipFormat={[Function]}
-        />
-      </ReportCard>
+                "complexityModel": Object {
+                  "easy": 111,
+                  "hard": 0,
+                  "medium": 11,
+                  "unknown": 0,
+                  "unsupported": 4,
+                },
+                "javaRuntimes": Array [],
+                "recommendedTargetsIMSModel": Object {
+                  "ocp": 111,
+                  "osp": 121,
+                  "rhel": 7,
+                  "rhv": 122,
+                  "total": 126,
+                },
+                "scanRunModels": Array [
+                  Object {
+                    "date": 1580774400000,
+                    "smartStateEnabled": true,
+                    "target": "VMware",
+                  },
+                ],
+                "summaryModels": Array [
+                  Object {
+                    "clusters": 1,
+                    "hosts": 2,
+                    "product": "VMware vCenter",
+                    "provider": "VMware",
+                    "sockets": 164,
+                    "version": "6.5",
+                    "vms": 126,
+                  },
+                ],
+                "workloadsDetectedOSTypeModels": Array [
+                  Object {
+                    "osName": "ServerNT",
+                    "total": 1,
+                  },
+                  Object {
+                    "osName": "Linux",
+                    "total": 4,
+                  },
+                ],
+              }
+            }
+          />
+        </GridItem>
+        <GridItem>
+          <Component
+            minHeight={311}
+            title="Application platforms information"
+          />
+        </GridItem>
+      </Grid>
     </StackItem>
     <StackItem
       isFilled={false}
     >
       <ReportCard
         skipBullseye={true}
-        title="Flags (factors that could increase migration complexity)"
+        title="Workloads detected"
       >
-        <Connect(FlagsTable)
+        <Connect(WorkloadsDetectedTable)
           reportId={1}
         />
       </ReportCard>

--- a/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
+++ b/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
@@ -142,20 +142,10 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
         }
       >
         <FancyChartDonut
-          chartLegendProps={
-            Object {
-              "height": 300,
-              "responsive": false,
-              "width": 210,
-              "y": 60,
-            }
-          }
           chartProps={
             Object {
-              "height": 250,
               "subTitle": "Total VMs",
               "title": "126",
-              "width": 250,
             }
           }
           data={

--- a/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
+++ b/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
@@ -210,6 +210,61 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
       <Component
         reportWorkloadSummary={
           Object {
+            "applicationPlatforms": Array [],
+            "complexityModel": Object {
+              "easy": 111,
+              "hard": 0,
+              "medium": 11,
+              "unknown": 0,
+              "unsupported": 4,
+            },
+            "javaRuntimes": Array [],
+            "recommendedTargetsIMSModel": Object {
+              "ocp": 111,
+              "osp": 121,
+              "rhel": 7,
+              "rhv": 122,
+              "total": 126,
+            },
+            "scanRunModels": Array [
+              Object {
+                "date": 1580774400000,
+                "smartStateEnabled": true,
+                "target": "VMware",
+              },
+            ],
+            "summaryModels": Array [
+              Object {
+                "clusters": 1,
+                "hosts": 2,
+                "product": "VMware vCenter",
+                "provider": "VMware",
+                "sockets": 164,
+                "version": "6.5",
+                "vms": 126,
+              },
+            ],
+            "workloadsDetectedOSTypeModels": Array [
+              Object {
+                "osName": "ServerNT",
+                "total": 1,
+              },
+              Object {
+                "osName": "Linux",
+                "total": 4,
+              },
+            ],
+          }
+        }
+      />
+    </StackItem>
+    <StackItem
+      isFilled={false}
+    >
+      <Component
+        reportWorkloadSummary={
+          Object {
+            "applicationPlatforms": Array [],
             "complexityModel": Object {
               "easy": 111,
               "hard": 0,

--- a/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
+++ b/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
@@ -59,6 +59,35 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
       isFilled={false}
     >
       <ReportCard
+        skipBullseye={true}
+        title="Target recommendation"
+      >
+        <div
+          className="pf-l-grid pf-m-all-6-col-on-md pf-m-all-3-col-on-lg pf-m-gutter"
+        >
+          <SolidCard
+            description="Workloads suitable for Red Hat Virtualization"
+            title="97% RHV"
+          />
+          <SolidCard
+            description="Workloads could be running on Red Hat OpenStack Platform"
+            title="96% OSP"
+          />
+          <SolidCard
+            description="Workloads possible to migrate to Red Hat Enterprise Linux"
+            title="6% RHEL"
+          />
+          <SolidCard
+            description="Workloads targeted for OpenShift virtualization"
+            title="88% OCP"
+          />
+        </div>
+      </ReportCard>
+    </StackItem>
+    <StackItem
+      isFilled={false}
+    >
+      <ReportCard
         title={
           <span>
             <span>
@@ -168,35 +197,6 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
     >
       <ReportCard
         skipBullseye={true}
-        title="Target recommendation"
-      >
-        <div
-          className="pf-l-grid pf-m-all-6-col-on-md pf-m-all-3-col-on-lg pf-m-gutter"
-        >
-          <SolidCard
-            description="Workloads suitable for Red Hat Virtualization"
-            title="97% RHV"
-          />
-          <SolidCard
-            description="Workloads could be running on Red Hat OpenStack Platform"
-            title="96% OSP"
-          />
-          <SolidCard
-            description="Workloads possible to migrate to Red Hat Enterprise Linux"
-            title="6% RHEL"
-          />
-          <SolidCard
-            description="Workloads targeted for OpenShift virtualization"
-            title="88% OCP"
-          />
-        </div>
-      </ReportCard>
-    </StackItem>
-    <StackItem
-      isFilled={false}
-    >
-      <ReportCard
-        skipBullseye={true}
         title="Flags (factors that could increase migration complexity)"
       >
         <Connect(FlagsTable)
@@ -207,74 +207,55 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
     <StackItem
       isFilled={false}
     >
-      <Grid
-        gutter="sm"
-        lg={4}
-      >
-        <GridItem>
-          <Component
-            minHeight={311}
-            title="OS information"
-          />
-        </GridItem>
-        <GridItem>
-          <Component
-            reportWorkloadSummary={
+      <Component
+        reportWorkloadSummary={
+          Object {
+            "complexityModel": Object {
+              "easy": 111,
+              "hard": 0,
+              "medium": 11,
+              "unknown": 0,
+              "unsupported": 4,
+            },
+            "javaRuntimes": Array [],
+            "recommendedTargetsIMSModel": Object {
+              "ocp": 111,
+              "osp": 121,
+              "rhel": 7,
+              "rhv": 122,
+              "total": 126,
+            },
+            "scanRunModels": Array [
               Object {
-                "complexityModel": Object {
-                  "easy": 111,
-                  "hard": 0,
-                  "medium": 11,
-                  "unknown": 0,
-                  "unsupported": 4,
-                },
-                "javaRuntimes": Array [],
-                "recommendedTargetsIMSModel": Object {
-                  "ocp": 111,
-                  "osp": 121,
-                  "rhel": 7,
-                  "rhv": 122,
-                  "total": 126,
-                },
-                "scanRunModels": Array [
-                  Object {
-                    "date": 1580774400000,
-                    "smartStateEnabled": true,
-                    "target": "VMware",
-                  },
-                ],
-                "summaryModels": Array [
-                  Object {
-                    "clusters": 1,
-                    "hosts": 2,
-                    "product": "VMware vCenter",
-                    "provider": "VMware",
-                    "sockets": 164,
-                    "version": "6.5",
-                    "vms": 126,
-                  },
-                ],
-                "workloadsDetectedOSTypeModels": Array [
-                  Object {
-                    "osName": "ServerNT",
-                    "total": 1,
-                  },
-                  Object {
-                    "osName": "Linux",
-                    "total": 4,
-                  },
-                ],
-              }
-            }
-          />
-        </GridItem>
-        <GridItem>
-          <Component
-            minHeight={311}
-            title="Application platforms information"
-          />
-        </GridItem>
-      </Grid>
+                "date": 1580774400000,
+                "smartStateEnabled": true,
+                "target": "VMware",
+              },
+            ],
+            "summaryModels": Array [
+              Object {
+                "clusters": 1,
+                "hosts": 2,
+                "product": "VMware vCenter",
+                "provider": "VMware",
+                "sockets": 164,
+                "version": "6.5",
+                "vms": 126,
+              },
+            ],
+            "workloadsDetectedOSTypeModels": Array [
+              Object {
+                "osName": "ServerNT",
+                "total": 1,
+              },
+              Object {
+                "osName": "Linux",
+                "total": 4,
+              },
+            ],
+          }
+        }
+      />
     </StackItem>
     <StackItem
       isFilled={false}


### PR DESCRIPTION
- https://issues.redhat.com/browse/MIGENG-534 and
- https://issues.redhat.com/browse/MIGENG-535

Depends on xavier-integration PR: https://github.com/project-xavier/xavier-integration/pull/102

Added 2 panels for Java runtimes and Application Platforms, both of them are inside the Workload Migration Summary Report:

![Screenshot from 2020-05-04 10-00-16](https://user-images.githubusercontent.com/2582866/80946356-258dbc00-8dee-11ea-8eb5-3c9ebf8986e6.png)

Minor enhancement that comes in this PR: Vertical alignment of donut chart legends.

Before:
![Screenshot from 2020-05-04 10-01-13](https://user-images.githubusercontent.com/2582866/80946578-a2209a80-8dee-11ea-8f11-7de36ade8e00.png)

After:
![Screenshot from 2020-05-04 09-59-48](https://user-images.githubusercontent.com/2582866/80946597-ae0c5c80-8dee-11ea-9b75-1c3a2c787867.png)

