### PR TITLE
MIGENG-623 modifying date fields adding string type

### DIFF
--- a/src/PresentationalComponents/Reports/ScansRunTable/ScansRunTable.test.tsx
+++ b/src/PresentationalComponents/Reports/ScansRunTable/ScansRunTable.test.tsx
@@ -13,6 +13,11 @@ const props: Props = {
             target: 'vSphere2',
             smartStateEnabled: false,
             date: 1568764800000
+        },
+        {
+            target: 'vSphere3',
+            smartStateEnabled: false,
+            date: "2020-05-26T09:50:25.771+0000"
         }
     ]
 };

--- a/src/PresentationalComponents/Reports/ScansRunTable/__snapshots__/ScansRunTable.test.tsx.snap
+++ b/src/PresentationalComponents/Reports/ScansRunTable/__snapshots__/ScansRunTable.test.tsx.snap
@@ -24,6 +24,11 @@ exports[`ScansRunTable should render table expect to render table using smartSta
           "Virt Platform",
           "September 18, 2019, UTC",
         ],
+        Array [
+          "vSphere3",
+          "Virt Platform",
+          "May 26, 2020, UTC",
+        ],
       ]
     }
     variant="compact"

--- a/src/models/Report.tsx
+++ b/src/models/Report.tsx
@@ -8,8 +8,8 @@ export interface Report {
     reportName: string;
     reportDescription: string;
     payloadName: string;
-    inserted: number;
-    lastUpdate: number;
+    inserted: number | string;
+    lastUpdate: number | string;
     status: 'CREATED' | 'IN_PROGRESS' | 'FAILED';
 }
 
@@ -55,7 +55,7 @@ export interface WorkloadDetectedOSTypeModel {
 export interface ScanRunModel {
     target: string;
     smartStateEnabled: boolean;
-    date: number;
+    date: number | string;
 }
 
 export interface WorkloadModel {
@@ -77,7 +77,7 @@ export interface ReportInitialSavingEstimation {
     id: number;
     customerId: string;
     fileName: string;
-    creationDate: Date;
+    creationDate: number | string;
     environmentModel: EnvironmentModel;
     sourceCostsModel: SourceCostsModel;
     sourceRampDownCostsModel: SourceRampDownCostsModel;

--- a/src/pages/Reports/Reports.test.tsx
+++ b/src/pages/Reports/Reports.test.tsx
@@ -4,7 +4,7 @@ import Reports, { Props } from './Reports';
 
 const props: Props = {
   reports: {
-    total: 2,
+    total: 3,
     items: [
       {
         id: 36,
@@ -22,6 +22,15 @@ const props: Props = {
         payloadName: "file2.json",
         inserted: 123654565464,
         lastUpdate: 123654565464,
+        status: 'IN_PROGRESS'
+      },
+      {
+        id: 38,
+        reportName: "My report name 38",
+        reportDescription: "My report description 38",
+        payloadName: "file3.json",
+        inserted: "2020-05-25T08:30:25.771+0000",
+        lastUpdate: "2020-05-26T09:50:25.771+0000",
         status: 'IN_PROGRESS'
       }
     ]

--- a/src/pages/Reports/__snapshots__/Reports.test.tsx.snap
+++ b/src/pages/Reports/__snapshots__/Reports.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Reports should render list depending of TOTAL value expect to render li
     <ToolbarGroup>
       <ToolbarItem>
         <Component
-          itemCount={2}
+          itemCount={3}
           onPageInput={[Function]}
           onPerPageSelect={[Function]}
           onSetPage={[Function]}
@@ -190,6 +190,30 @@ exports[`Reports should render list depending of TOTAL value expect to render li
             },
           ],
         },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <span>
+                My report name 38
+              </span>,
+            },
+            Object {
+              "title": <p>
+                <InProgressIcon
+                  className="progress"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
+                />
+                 Analyzing the upload file
+              </p>,
+            },
+            Object {
+              "title": "",
+            },
+          ],
+        },
       ]
     }
   >
@@ -201,7 +225,7 @@ exports[`Reports should render list depending of TOTAL value expect to render li
           colSpan={10}
         >
           <Component
-            itemCount={2}
+            itemCount={3}
             onPageInput={[Function]}
             onPerPageSelect={[Function]}
             onSetPage={[Function]}


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-623
UI changes needed to support the change on the backend that will export JSON dates using ISO-8601 format instead of a timestamp.

Elements covered :
* Return correct Error Codes ----> IMPLEMENTED
* Pagination parameters : limit,offset ----> NOT APPLICABLE
* Pagination maximum value for limit ----> NOT APPLICABLE
* Pagination response object : meta,links,data ----> NOT APPLICABLE
* Links object containing First and Last ----> NOT APPLICABLE
* Filtering results returned in the data element ----> NOT APPLICABLE
* Sorting response inside data element ----> NOT APPLICABLE
* Date data type folling ISO-8601 format ----> IMPLEMENTED
* Objects canonical ID ----> ON HOLD
* Oerations MUST have an operationId defined ----> IMPLEMENTED


Depends on : https://github.com/project-xavier/xavier-integration/pull/109