### PR TITLE
fix Dependabot integration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,8 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
+    default_reviewers:
+      - "carlosthe19916"
     allowed_updates:
       - match:
           dependency_name: "@redhat-cloud-services/frontend*"


### PR DESCRIPTION
it seems that `default_reviewers` is needed since with this change it seems to work in my fork: https://github.com/carlosthe19916/xavier-ui/pulls