### PR TITLE
MIGENG-674: Element is not displayed properly

### DIFF
--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
@@ -55,7 +55,7 @@ export const ApplicationPlatformsCard: React.FC<Props> = ({ reportWorkloadSummar
     }));
 
     const tickFormat = (label: string, value: number, data: any) => {
-        return `${label}: ${data}`;
+        return `${label}: ${formatNumber(data, 0)}`;
     };
     const tooltipFormat = ({ datum }) =>
         `${datum.x}: ${formatPercentage(datum.y, 2)} \n Total: ${formatNumber(datum.extraData, 0)}`;

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
@@ -56,7 +56,7 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
     }));
 
     const tickFormat = (label: string, value: number, data: any) => {
-        return `${label}: ${data}`;
+        return `${label}: ${formatNumber(data, 0)}`;
     };
     const tooltipFormat = ({ datum }) =>
         `${datum.x}: ${formatPercentage(datum.y, 2)} \n Total: ${formatNumber(datum.extraData, 0)}`;

--- a/src/PresentationalComponents/WorkladSummary/OSInformation/OSInformation.tsx
+++ b/src/PresentationalComponents/WorkladSummary/OSInformation/OSInformation.tsx
@@ -60,7 +60,7 @@ export const OSInformation: React.FC<Props> = ({ reportWorkloadSummary }) => {
     }));
 
     const tickFormat = (label: string, value: number, data: any) => {
-        return `${label}: ${data}`;
+        return `${label}: ${formatNumber(data, 0)}`;
     };
     const tooltipFormat = ({ datum }) =>
         `${datum.x}: ${formatPercentage(datum.y, 2)} \n Total: ${formatNumber(datum.extraData, 0)}`;

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -134,7 +134,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
             height: 300,
             domainPadding: {
                 x: 110,
-                y: 60
+                y: 30
             },
             padding: { left: 110, right: 20, bottom: 30, top: 0 }
         };
@@ -275,7 +275,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
         const chartProps = {
             title: formatValue(total, 'usd', { fractionDigits: 0 }),
             height: 240,
-            width: 470
+            width: 520
         };
 
         const chartData: FancyChartDonutData[] = [
@@ -342,7 +342,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
             height: 350,
             domainPadding: {
                 x: 50,
-                y: 60
+                y: 30
             },
             padding: { left: 110, right: 0, bottom: 100, top: 0 }
         };

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -134,7 +134,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
             height: 300,
             domainPadding: {
                 x: 110,
-                y: 30
+                y: 0
             },
             padding: { left: 110, right: 20, bottom: 30, top: 0 }
         };


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-674

- Initial Savings estimation
  - `Total costs during 3 years migration`: Increased `width` of legends
  - `Cost expenditure comparison during the 3 year migration` and `Project cost breakdown` Reduce padding to 30 so `Y` axis is shown correctly

 Steps to reproduce the error and then compare it with the current PR: https://issues.redhat.com/browse/MIGENG-674?focusedCommentId=14203203&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14203203
 
