### PR TITLE
MIGENG-654: UI changes for Workload Migration Summary UI - Fixes

### DIFF
--- a/src/PresentationalComponents/FancyChartDonut/FancyChartDonut.tsx
+++ b/src/PresentationalComponents/FancyChartDonut/FancyChartDonut.tsx
@@ -74,7 +74,7 @@ class FancyChartDonut extends Component<Props, State> {
                                 top: 20
                             }}
                             legendAllowWrap={true}
-                            width={420}
+                            width={450}
                             height={190}
                             { ...chartProps }
                         />

--- a/src/PresentationalComponents/FancyChartDonut/__snapshots__/FancyChartDonut.test.tsx.snap
+++ b/src/PresentationalComponents/FancyChartDonut/__snapshots__/FancyChartDonut.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`FancyChartDonut expect to render with minimun props 1`] = `
         }
         themeColor="multi-ordered"
         themeVariant="light"
-        width={420}
+        width={450}
       />
     </div>
   </div>

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/ApplicationPlatformsCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Bullseye, Grid, GridItem } from '@patternfly/react-core';
+import { Bullseye, Grid, GridItem, Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 import ReportCard from '../../ReportCard';
 import { ReportWorkloadSummary, ApplicationPlatformModel } from '../../../models';
 import FancyChartDonut from '../../FancyChartDonut';
@@ -13,7 +14,16 @@ interface Props {
 }
 
 export const ApplicationPlatformsCard: React.FC<Props> = ({ reportWorkloadSummary }) => {
-    const title = 'Application server platform information';
+    const title = (
+        <span>
+            <span>Application server platform information</span>&nbsp;
+            <span>
+                <Tooltip position="top" content={<div>See the Workload migration inventory for details</div>}>
+                    <HelpIcon />
+                </Tooltip>
+            </span>
+        </span>
+    );
 
     if (
         !reportWorkloadSummary ||
@@ -76,7 +86,10 @@ export const ApplicationPlatformsCard: React.FC<Props> = ({ reportWorkloadSummar
                 <GridItem>
                     <Bullseye>
                         <SolidCard
-                            title={`Application server environments that can be replatformed with JBoss EAP: ${formatNumber(reportWorkloadSummary.recommendedTargetsIMSModel.jbosseap || 0, 0)}`}
+                            title={`Application server environments that can be replatformed with JBoss EAP: ${formatNumber(
+                                reportWorkloadSummary.recommendedTargetsIMSModel.jbosseap || 0,
+                                0
+                            )}`}
                             // description="App platforms that can be replatformed with JBoss EAP"
                             width={510}
                         />

--- a/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/__snapshots__/ApplicationPlatformsCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/ApplicationPlatformsCard/__snapshots__/ApplicationPlatformsCard.test.tsx.snap
@@ -3,7 +3,57 @@
 exports[`ApplicationPlatformsCard expect to render 1`] = `
 <ReportCard
   skipBullseye={true}
-  title="Application server platform information"
+  title={
+    <span>
+      <span>
+        Application server platform information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
 >
   <Grid
     hasGutter={true}
@@ -56,7 +106,57 @@ exports[`ApplicationPlatformsCard expect to render 1`] = `
 
 exports[`ApplicationPlatformsCard expect to render empty card when no java runtimes 1`] = `
 <Component
-  cardTitle="Application server platform information"
+  cardTitle={
+    <span>
+      <span>
+        Application server platform information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
   description="No application server platforms have been discovered."
   message="No application server platforms found"
 />
@@ -64,7 +164,57 @@ exports[`ApplicationPlatformsCard expect to render empty card when no java runti
 
 exports[`ApplicationPlatformsCard expect to render empty card when undefined reportWorkloadSummary 1`] = `
 <Component
-  cardTitle="Application server platform information"
+  cardTitle={
+    <span>
+      <span>
+        Application server platform information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
   description="No application server platforms have been discovered."
   message="No application server platforms found"
 />

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/JavaRuntimesCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Bullseye, GridItem, Grid } from '@patternfly/react-core';
+import { Bullseye, GridItem, Grid, Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 import ReportCard from '../../ReportCard';
 import { ReportWorkloadSummary, JavaRuntimeModel } from '../../../models';
 import FancyChartDonut from '../../FancyChartDonut';
@@ -13,7 +14,16 @@ interface Props {
 }
 
 export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => {
-    const title = 'Oracle Java runtime information';
+    const title = (
+        <span>
+            <span>Oracle Java runtime information</span>&nbsp;
+            <span>
+                <Tooltip position="top" content={<div>See the Workload migration inventory for details</div>}>
+                    <HelpIcon />
+                </Tooltip>
+            </span>
+        </span>
+    );
 
     if (
         !reportWorkloadSummary ||
@@ -77,10 +87,13 @@ export const JavaRuntimesCard: React.FC<Props> = ({ reportWorkloadSummary }) => 
                 <GridItem>
                     <Bullseye>
                         <SolidCard
-                            title={`Oracle JDKs that can be replaced with Open JDK: ${formatNumber(reportWorkloadSummary.recommendedTargetsIMSModel.openjdk || 0, 0)}`}
+                            title={`Oracle JDKs that can be replaced with Open JDK: ${formatNumber(
+                                reportWorkloadSummary.recommendedTargetsIMSModel.openjdk || 0,
+                                0
+                            )}`}
                             width={510}
                         />
-                    </Bullseye>                    
+                    </Bullseye>
                 </GridItem>
             </Grid>
         </ReportCard>

--- a/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/JavaRuntimesCard/__snapshots__/JavaRuntimesCard.test.tsx.snap
@@ -3,7 +3,57 @@
 exports[`JavaRuntimesCard expect to render 1`] = `
 <ReportCard
   skipBullseye={true}
-  title="Oracle Java runtime information"
+  title={
+    <span>
+      <span>
+        Oracle Java runtime information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
 >
   <Grid
     hasGutter={true}
@@ -56,7 +106,57 @@ exports[`JavaRuntimesCard expect to render 1`] = `
 
 exports[`JavaRuntimesCard expect to render empty card when no java runtimes 1`] = `
 <Component
-  cardTitle="Oracle Java runtime information"
+  cardTitle={
+    <span>
+      <span>
+        Oracle Java runtime information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
   description="No instances of Oracle JDKs have been discovered."
   message="No instances found"
 />
@@ -64,7 +164,57 @@ exports[`JavaRuntimesCard expect to render empty card when no java runtimes 1`] 
 
 exports[`JavaRuntimesCard expect to render empty card when undefined reportWorkloadSummary 1`] = `
 <Component
-  cardTitle="Oracle Java runtime information"
+  cardTitle={
+    <span>
+      <span>
+        Oracle Java runtime information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
   description="No instances of Oracle JDKs have been discovered."
   message="No instances found"
 />

--- a/src/PresentationalComponents/WorkladSummary/OSInformation/OSInformation.tsx
+++ b/src/PresentationalComponents/WorkladSummary/OSInformation/OSInformation.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Bullseye, Grid, GridItem } from '@patternfly/react-core';
+import { Bullseye, Grid, GridItem, Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
 import ReportCard from '../../ReportCard';
 import { ReportWorkloadSummary, OSInformationModel } from '../../../models';
 import FancyChartDonut from '../../FancyChartDonut';
@@ -13,7 +15,16 @@ interface Props {
 }
 
 export const OSInformation: React.FC<Props> = ({ reportWorkloadSummary }) => {
-    const title = 'Operating system information';
+    const title = (
+        <span>
+            <span>Operating system information</span>&nbsp;
+            <span>
+                <Tooltip position="top" content={<div>See the Workload migration inventory for details</div>}>
+                    <HelpIcon />
+                </Tooltip>
+            </span>
+        </span>
+    );
 
     if (
         !reportWorkloadSummary ||
@@ -21,7 +32,11 @@ export const OSInformation: React.FC<Props> = ({ reportWorkloadSummary }) => {
         reportWorkloadSummary.osInformation.length === 0
     ) {
         return (
-            <EmptyCard cardTitle={title} message="Not enough data" description="Could not extract operating system information." />
+            <EmptyCard
+                cardTitle={title}
+                message="Not enough data"
+                description="Could not extract operating system information."
+            />
         );
     }
 
@@ -81,7 +96,10 @@ export const OSInformation: React.FC<Props> = ({ reportWorkloadSummary }) => {
                 <GridItem>
                     <Bullseye>
                         <SolidCard
-                            title={`Operating systems that can be migrated to Red Hat Enterprise Linux: ${formatNumber(reportWorkloadSummary.recommendedTargetsIMSModel.rhel || 0, 0)}`}
+                            title={`Operating systems that can be migrated to Red Hat Enterprise Linux: ${formatNumber(
+                                reportWorkloadSummary.recommendedTargetsIMSModel.rhel || 0,
+                                0
+                            )}`}
                             width={510}
                         />
                     </Bullseye>

--- a/src/PresentationalComponents/WorkladSummary/OSInformation/__snapshots__/OSInformation.test.tsx.snap
+++ b/src/PresentationalComponents/WorkladSummary/OSInformation/__snapshots__/OSInformation.test.tsx.snap
@@ -3,7 +3,57 @@
 exports[`JavaRuntimesCard expect to render 1`] = `
 <ReportCard
   skipBullseye={true}
-  title="Operating system information"
+  title={
+    <span>
+      <span>
+        Operating system information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
 >
   <Grid
     hasGutter={true}
@@ -67,7 +117,57 @@ exports[`JavaRuntimesCard expect to render 1`] = `
 
 exports[`JavaRuntimesCard expect to render empty card when no java runtimes 1`] = `
 <Component
-  cardTitle="Operating system information"
+  cardTitle={
+    <span>
+      <span>
+        Operating system information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
   description="Could not extract operating system information."
   message="Not enough data"
 />
@@ -75,7 +175,57 @@ exports[`JavaRuntimesCard expect to render empty card when no java runtimes 1`] 
 
 exports[`JavaRuntimesCard expect to render empty card when undefined reportWorkloadSummary 1`] = `
 <Component
-  cardTitle="Operating system information"
+  cardTitle={
+    <span>
+      <span>
+        Operating system information
+      </span>
+       
+      <span>
+        <Tooltip
+          appendTo={[Function]}
+          aria="describedby"
+          boundary="window"
+          className=""
+          content={
+            <div>
+              See the Workload migration inventory for details
+            </div>
+          }
+          distance={15}
+          enableFlip={true}
+          entryDelay={500}
+          exitDelay={500}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          id=""
+          isAppLauncher={false}
+          isContentLeftAligned={false}
+          isVisible={false}
+          maxWidth="18.75rem"
+          position="top"
+          tippyProps={Object {}}
+          trigger="mouseenter focus"
+          zIndex={9999}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Tooltip>
+      </span>
+    </span>
+  }
   description="Could not extract operating system information."
   message="Not enough data"
 />

--- a/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
+++ b/src/pages/ReportView/InitialSavingsEstimation/InitialSavingsEstimation.tsx
@@ -223,7 +223,7 @@ class InitialSavingsEstimation extends React.Component<Props, State> {
                 <Tooltip
                     position="right"
                     content={
-                        <div>Includes VMWare maintenance, Red Hat Virtualization subscriptions, training and services</div>
+                        <div>Includes VMware maintenance, Red Hat Virtualization subscriptions, training and services</div>
                     }
                 >
                     <HelpIcon />

--- a/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
+++ b/src/pages/ReportView/WorkloadSummary/WorkloadSummary.tsx
@@ -212,8 +212,8 @@ export class WorkloadMigrationSummary extends React.Component<WorkloadMigrationS
                         description="Workloads possible to migrate to Red Hat Enterprise Linux"
                     /> */}
                     <SolidCard
-                        title={`${formatPercentage(percentages[3], 0)} Red Hat OpenShift virtualization`}
-                        description="Workloads targeted for OpenShift virtualization"
+                        title={`${formatPercentage(percentages[3], 0)} Red Hat OpenShift Virtualization`}
+                        description="Workloads targeted for Red Hat OpenShift Virtualization"
                     />
                 </div>
             </ReportCard>

--- a/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
+++ b/src/pages/ReportView/WorkloadSummary/__snapshots__/WorkloadSummary.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`WorkloadMigrationSummary expect to render reports 1`] = `
             title="96% Red Hat OpenStack Platform"
           />
           <SolidCard
-            description="Workloads targeted for OpenShift virtualization"
-            title="88% Red Hat OpenShift virtualization"
+            description="Workloads targeted for Red Hat OpenShift Virtualization"
+            title="88% Red Hat OpenShift Virtualization"
           />
         </div>
       </ReportCard>


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-654

Fixes to comment: https://issues.redhat.com/browse/MIGENG-654?focusedCommentId=15157206&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15157206


- Use of **Red Hat OpenShift Virtualization** with **V** capitalized:

![Screenshot from 2020-09-22 15-39-00](https://user-images.githubusercontent.com/2582866/93890017-2dd98b80-fcea-11ea-8e1d-4db54aadc7c7.png)


- Added "See the Workload migration inventory for details" tooltip to the 3 Cards "Operating system information", "Oracle Java runtime information", and "Application server platform information". All those 3 cards have the same tooltip message

![Screenshot from 2020-09-22 15-37-55](https://user-images.githubusercontent.com/2582866/93890292-7bee8f00-fcea-11ea-9c64-e5f433844121.png)


- Changed "VMWare" to "VMware":

![Screenshot from 2020-09-22 15-35-50](https://user-images.githubusercontent.com/2582866/93890023-2f0ab880-fcea-11ea-8e7c-65294ff08999.png)
